### PR TITLE
Add random_seed option for reproducible particle initialization

### DIFF
--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -485,6 +485,7 @@ class MovingWindow:
             x_list = typed.List([p.particles[ispec].x for p in patches])
             y_list = typed.List([p.particles[ispec].y for p in patches])
             w_list = typed.List([p.particles[ispec].w for p in patches])
+            gens = typed.List(sim.rand_gen.spawn(len(patches)))
 
             num_macro_particles = get_num_macro_particles_2d(
                 s.density_jit,
@@ -509,7 +510,8 @@ class MovingWindow:
                 len(patches), 
                 s.density_min, 
                 s.ppc_jit,
-                x_list, y_list, w_list
+                x_list, y_list, w_list,
+                gens
             )
 
     def _fill_particles_3d(self, sim: Simulation, patches: Sequence[Patch3D]):

--- a/src/lambdapic/core/patch/cpu.py
+++ b/src/lambdapic/core/patch/cpu.py
@@ -19,7 +19,7 @@ def get_num_macro_particles_2d(density_func, xaxis_list, yaxis_list, npatches, d
 
 
 @njit(cache=False, parallel=True)
-def fill_particles_2d(density_func, xaxis_list, yaxis_list, npatches, dens_min, ppc_func, x_list, y_list, w_list):
+def fill_particles_2d(density_func, xaxis_list, yaxis_list, npatches, dens_min, ppc_func, x_list, y_list, w_list, rand_gens):
     dx = xaxis_list[0][1] - xaxis_list[0][0]
     dy = yaxis_list[0][1] - yaxis_list[0][0]
     for ipatch in prange(npatches):
@@ -30,13 +30,16 @@ def fill_particles_2d(density_func, xaxis_list, yaxis_list, npatches, dens_min, 
         y = y_list[ip]
         w = w_list[ip]
         ipart = 0
+        
+        gen = rand_gens[ipatch]
+        
         for x_grid in xaxis:
             for y_grid in yaxis:
                 dens = density_func(x_grid, y_grid)
                 ppc = int(ppc_func(x_grid, y_grid))
                 if dens > dens_min:
-                    x[ipart:ipart+ppc] = np.random.uniform(-dx/2, dx/2, ppc) + x_grid
-                    y[ipart:ipart+ppc] = np.random.uniform(-dy/2, dy/2, ppc) + y_grid
+                    x[ipart:ipart+ppc] = gen.uniform(-dx/2, dx/2, ppc) + x_grid
+                    y[ipart:ipart+ppc] = gen.uniform(-dy/2, dy/2, ppc) + y_grid
                     w[ipart:ipart+ppc] = dens*dx*dy / ppc
                     ipart += ppc
 
@@ -62,8 +65,8 @@ def get_num_macro_particles_3d(
 
 @njit(cache=False, parallel=True)
 def fill_particles_3d(
-    density_func, xaxis_list, yaxis_list, zaxis_list, npatches, dens_min, ppc_func, 
-    x_list, y_list, z_list, w_list
+    density_func, xaxis_list, yaxis_list, zaxis_list, npatches, dens_min, ppc_func,
+    x_list, y_list, z_list, w_list, rand_gens
 ):
     dx = xaxis_list[0][1] - xaxis_list[0][0]
     dy = yaxis_list[0][1] - yaxis_list[0][0]
@@ -80,6 +83,8 @@ def fill_particles_3d(
         w = w_list[ip]
         ipart = 0
         
+        gen = rand_gens[ipatch]
+        
         for x_grid in xaxis:
             for y_grid in yaxis:
                 for z_grid in zaxis:
@@ -87,8 +92,8 @@ def fill_particles_3d(
                     ppc = int(ppc_func(x_grid, y_grid, z_grid))
                     if dens > dens_min:
                         # Generate particles in 3D cell
-                        x[ipart:ipart+ppc] = np.random.uniform(-dx/2, dx/2, ppc) + x_grid
-                        y[ipart:ipart+ppc] = np.random.uniform(-dy/2, dy/2, ppc) + y_grid 
-                        z[ipart:ipart+ppc] = np.random.uniform(-dz/2, dz/2, ppc) + z_grid
+                        x[ipart:ipart+ppc] = gen.uniform(-dx/2, dx/2, ppc) + x_grid
+                        y[ipart:ipart+ppc] = gen.uniform(-dy/2, dy/2, ppc) + y_grid
+                        z[ipart:ipart+ppc] = gen.uniform(-dz/2, dz/2, ppc) + z_grid
                         w[ipart:ipart+ppc] = dens*dx*dy*dz / ppc
                         ipart += ppc

--- a/src/lambdapic/core/patch/patch.py
+++ b/src/lambdapic/core/patch/patch.py
@@ -813,7 +813,8 @@ class Patches:
         num_macro_particles_sum = sum(num_macro_particles)
         return num_macro_particles_sum
 
-    def fill_particles(self):
+    def fill_particles(self, rand_gen: np.random.Generator):
+        rand_gens = typed.List(rand_gen.spawn(self.npatches))
         for ispec, s in enumerate(self.species):
             if s.density is not None:
                 if self.dimension == 2:
@@ -825,12 +826,13 @@ class Patches:
                     
                     fill_particles_2d(
                         s.density_jit,
-                        xaxis, 
-                        yaxis, 
-                        self.npatches, 
-                        s.density_min, 
+                        xaxis,
+                        yaxis,
+                        self.npatches,
+                        s.density_min,
                         s.ppc_jit,
-                        x_list, y_list, w_list
+                        x_list, y_list, w_list,
+                        rand_gens
                     )
                     
                 elif self.dimension == 3:
@@ -844,13 +846,14 @@ class Patches:
                     
                     fill_particles_3d(
                         s.density_jit,
-                        xaxis, 
+                        xaxis,
                         yaxis,
                         zaxis,
-                        self.npatches, 
-                        s.density_min, 
+                        self.npatches,
+                        s.density_min,
                         s.ppc_jit,
-                        x_list, y_list, z_list, w_list
+                        x_list, y_list, z_list, w_list,
+                        rand_gens
                     )
     
         self.update_lists()

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,0 +1,156 @@
+"""
+Test random seed reproducibility in LambdaPIC simulations.
+"""
+
+import numpy as np
+import pytest
+from lambdapic import Simulation, Simulation3D, Electron
+
+
+def test_random_seed_reproducibility_2d():
+    """Test that 2D simulations with the same seed produce identical results."""
+    # Create two simulations with the same seed
+    sim1 = Simulation(
+        nx=32, ny=32, dx=1.0, dy=1.0,
+        npatch_x=2, npatch_y=2,
+        random_seed=42
+    )
+    
+    sim2 = Simulation(
+        nx=32, ny=32, dx=1.0, dy=1.0,
+        npatch_x=2, npatch_y=2,
+        random_seed=42
+    )
+    
+    # Add the same species to both simulations
+    electron1 = Electron(density=lambda x, y: 1.0, ppc=4)
+    electron2 = Electron(density=lambda x, y: 1.0, ppc=4)
+    
+    sim1.add_species([electron1])
+    sim2.add_species([electron2])
+    
+    # Initialize both simulations
+    sim1.initialize()
+    sim2.initialize()
+    
+    # Check that particle positions are identical
+    for ipatch in range(len(sim1.patches)):
+        for ispec in range(len(sim1.patches.species)):
+            particles1 = sim1.patches[ipatch].particles[ispec]
+            particles2 = sim2.patches[ipatch].particles[ispec]
+            
+            # Check same number of particles
+            assert particles1.npart == particles2.npart
+            
+            # Check identical positions
+            np.testing.assert_array_equal(particles1.x, particles2.x)
+            np.testing.assert_array_equal(particles1.y, particles2.y)
+            np.testing.assert_array_equal(particles1.w, particles2.w)
+
+
+def test_random_seed_different_results():
+    """Test that different seeds produce different results."""
+    # Create two simulations with different seeds
+    sim1 = Simulation(
+        nx=32, ny=32, dx=1.0, dy=1.0,
+        npatch_x=2, npatch_y=2,
+        random_seed=42
+    )
+    
+    sim2 = Simulation(
+        nx=32, ny=32, dx=1.0, dy=1.0,
+        npatch_x=2, npatch_y=2,
+        random_seed=123
+    )
+    
+    # Add the same species to both simulations
+    electron = Electron(density=lambda x, y: 1.0, ppc=4)
+    
+    sim1.add_species([electron])
+    sim2.add_species([electron])
+    
+    # Initialize both simulations
+    sim1.initialize()
+    sim2.initialize()
+    
+    # Check that particle positions are different
+    positions_different = False
+    for ipatch in range(len(sim1.patches)):
+        for ispec in range(len(sim1.patches.species)):
+            particles1 = sim1.patches[ipatch].particles[ispec]
+            particles2 = sim2.patches[ipatch].particles[ispec]
+            
+            # Check if any positions are different
+            if not np.array_equal(particles1.x, particles2.x):
+                positions_different = True
+                break
+    
+    assert positions_different, "Different seeds should produce different particle positions"
+
+
+def test_random_seed_none():
+    """Test that random_seed=None uses non-deterministic initialization."""
+    sim = Simulation(
+        nx=32, ny=32, dx=1.0, dy=1.0,
+        npatch_x=2, npatch_y=2,
+        random_seed=None
+    )
+    
+    electron = Electron(density=lambda x, y: 1.0, ppc=4)
+    
+    sim.add_species([electron])
+    
+    # Should initialize without error
+    sim.initialize()
+
+
+def test_random_seed_reproducibility_3d():
+    """Test that 3D simulations with the same seed produce identical results."""
+    # Create two 3D simulations with the same seed
+    sim1 = Simulation3D(
+        nx=16, ny=16, nz=16,
+        dx=1.0, dy=1.0, dz=1.0,
+        npatch_x=2, npatch_y=2, npatch_z=2,
+        random_seed=42
+    )
+    
+    sim2 = Simulation3D(
+        nx=16, ny=16, nz=16,
+        dx=1.0, dy=1.0, dz=1.0,
+        npatch_x=2, npatch_y=2, npatch_z=2,
+        random_seed=42
+    )
+    
+    # Add the same species to both simulations
+    electron1 = Electron(density=lambda x, y, z: 1.0, ppc=4)
+    electron2 = Electron(density=lambda x, y, z: 1.0, ppc=4)
+    
+    sim1.add_species([electron1])
+    sim2.add_species([electron2])
+    
+    # Initialize both simulations
+    sim1.initialize()
+    sim2.initialize()
+    
+    # Check that particle positions are identical
+    for ipatch in range(len(sim1.patches)):
+        for ispec in range(len(sim1.patches.species)):
+            particles1 = sim1.patches[ipatch].particles[ispec]
+            particles2 = sim2.patches[ipatch].particles[ispec]
+            
+            # Check same number of particles
+            assert particles1.npart == particles2.npart
+            
+            # Check identical positions
+            np.testing.assert_array_equal(particles1.x, particles2.x)
+            np.testing.assert_array_equal(particles1.y, particles2.y)
+            np.testing.assert_array_equal(particles1.z, particles2.z)
+            np.testing.assert_array_equal(particles1.w, particles2.w)
+
+
+if __name__ == "__main__":
+    test_random_seed_reproducibility_2d()
+    test_random_seed_different_results()
+    test_random_seed_none()
+    test_random_seed_reproducibility_3d()
+    print("All random seed tests passed!")


### PR DESCRIPTION
Introduce a random_seed parameter to enable reproducible initialization of particles in simulations. Update relevant functions to utilize the random seed for generating random numbers.