### PR TITLE
feat: implement species auxiliary attributes passing

### DIFF
--- a/src/lambdapic/core/species.py
+++ b/src/lambdapic/core/species.py
@@ -102,6 +102,7 @@ class Species:
         self.density_jit: Callable | None = None
         self.ppc_jit: Callable | None = None
 
+        self._aux_attrs: list[str] = []
         self._ispec: int | None = None
         
     @property

--- a/src/lambdapic/simulation.py
+++ b/src/lambdapic/simulation.py
@@ -295,7 +295,7 @@ class Simulation:
         self._init_pml()
         
         for s in self.species:
-            npart = self.patches.add_species(s)
+            npart = self.patches.add_species(s, aux_attrs=s._aux_attrs)
             logger.info(f"Rank {rank}: Adding {npart:,} macro particles to {s.name}")
             
                 


### PR DESCRIPTION
This PR adds support for auxiliary attributes in the Species class and passes them when adding species to patches.