### PR TITLE
feat(callback): implement float interval support

### DIFF
--- a/example/laser-target.py
+++ b/example/laser-target.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
                     dict(field=n_ele.density, scale=1/nc, cmap='Grays', vmin=0, vmax=20), 
                     dict(field='ey',  scale=e/(m_e*c*omega0), cmap='bwr_alpha', vmin=-laser.a0, vmax=laser.a0)
                 ],
-                prefix='laser-target', interval=500,
+                prefix='laser-target', interval=10e-15,
             ),
             SaveFieldsToHDF5('laser-target/fields', 500, ['ex', 'ey', 'ez', 'bx', 'by', 'bz', 'rho']),
             SaveSpeciesDensityToHDF5(carbon, 'laser-target/density', 500),

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -29,7 +29,7 @@ class SaveFieldsToHDF5(Callback):
 
     Args:
         prefix (str): Prefix for output filenames. For example, if prefix is 'output', the files will be named 'output/t000100.h5', 'output/t000200.h5', etc.
-        interval (Union[int, Callable], optional): Number of timesteps between saves, or a 
+        interval (Union[int, float, Callable], optional): Number of timesteps between saves, or a 
             function(sim) -> bool that determines when to save. Defaults to 100.
         components (Optional[List[str]], optional): List of field components to save. 
             Available: ['ex','ey','ez','bx','by','bz','jx','jy','jz','rho']. 
@@ -38,7 +38,7 @@ class SaveFieldsToHDF5(Callback):
     stage="maxwell second"
     def __init__(self, 
                  prefix: Union[str, Path]='', 
-                 interval: Union[int, Callable] = 100,
+                 interval: Union[int, float, Callable] = 100,
                  components: Optional[List[str]] = None) -> None:
         self.prefix = Path(prefix)
         self.interval = interval
@@ -191,11 +191,11 @@ class SaveSpeciesDensityToHDF5(Callback):
     Args:
         species (Species): The species whose density will be saved
         prefix (str): Prefix for output filenames. For example, if prefix is 'output', the files will be named 'output/{species.name}_000100.h5', 'output/{species.name}_000200.h5', etc.
-        interval (Union[int, Callable], optional): Number of timesteps between saves, or a 
+        interval (Union[int, float, Callable], optional): Number of timesteps between saves, or a 
             function(sim) -> bool that determines when to save. Defaults to 100.
     """
     stage = "current deposition"
-    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, Callable] = 100):
+    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100):
         self.species = species
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)
@@ -370,7 +370,7 @@ class SaveParticlesToHDF5(Callback):
     Args:
         species (Species): The particle species to save
         prefix (str): Prefix for output filenames. For example, if prefix is 'output', the files will be named 'output/{species.name}_particles_0000100.h5'.
-        interval (Union[int, Callable], optional): Number of timesteps between saves, or a
+        interval (Union[int, float, Callable], optional): Number of timesteps between saves, or a
             function(sim) -> bool that determines when to save. Defaults to 100.
         attrs (Optional[List[str]], optional): List of particle attributes to save.
             If None, saves all attributes.
@@ -379,7 +379,7 @@ class SaveParticlesToHDF5(Callback):
     def __init__(self,
                  species: Species,
                  prefix: Union[str, Path]='',
-                 interval: Union[int, Callable] = 100,
+                 interval: Union[int, float, Callable] = 100,
                  attrs: Optional[List[str]] = None) -> None:
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)

--- a/src/lambdapic/callback/plot.py
+++ b/src/lambdapic/callback/plot.py
@@ -29,7 +29,7 @@ class PlotFields(Callback):
             - vmin: Minimum value for normalization (optional)
             - vmax: Maximum value for normalization (optional)
         prefix (Union[str, Path]): Output directory for plots
-        interval (Union[int, Callable] = 100): Save interval
+        interval (Union[int, float, Callable] = 100): Save interval
         figsize (Tuple[float, float] = (10, 6)): Figure size
         dpi (int = 300): Image DPI
 
@@ -55,7 +55,7 @@ class PlotFields(Callback):
     def __init__(self,
                  field_configs: List[Dict],
                  prefix: Union[str, Path],
-                 interval: Union[int, Callable] = 100,
+                 interval: Union[int, float, Callable] = 100,
                  figsize: tuple | None = None,
                  dpi: int = 300):
         self.prefix = Path(prefix)

--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -237,7 +237,7 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
     Args:
         sim (Simulation): Simulation instance.
         species (Species): Species instance to extract density from.
-        interval (Union[int, Callable], optional): Number of timesteps between saves, or a function(sim) -> bool that determines when to save. Defaults to 100.
+        interval (Union[int, float, Callable], optional): Number of timesteps between saves, or a function(sim) -> bool that determines when to save. Defaults to 100.
 
     Example:
 
@@ -253,7 +253,7 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
     """
 
     stage = "current deposition"
-    def __init__(self, sim: Simulation, species: Species, interval: Union[int, Callable] = 100) -> None:
+    def __init__(self, sim: Simulation, species: Species, interval: Union[int, float, Callable] = 100) -> None:
         self.species = species
         self.interval = interval
         self.prev_rho = None
@@ -746,7 +746,7 @@ class SetTemperature(Callback):
         interval (int or callable): Frequency (in timesteps) or callable(sim) for when to apply, defaults to run at the first timestep only once.
     """
     stage: str = "start"
-    def __init__(self, species: Species, temperature: float|int|List[float|int], interval: Union[int, Callable]|None = None) -> None:
+    def __init__(self, species: Species, temperature: float|int|List[float|int], interval: Union[int, float, Callable]|None = None) -> None:
         self.species = species
 
         if isinstance(temperature, (float, int)):

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -13,6 +13,18 @@ def mock_sim():
     sim.mpi.rank = 0
     return sim
 
+@pytest.fixture
+def mock_sim_with_time():
+    """Fixture providing a mock simulation with time and dt properties."""
+    sim = Mock()
+    sim.patches = []
+    sim.itime = 0
+    sim.time = 0.0
+    sim.dt = 0.1  # Default time step
+    sim.mpi.rank = 0
+    sim.mpi.comm.Barrier = Mock()
+    return sim
+
 @pytest.mark.unit
 class TestCallback:
         
@@ -146,3 +158,108 @@ class TestCallback:
         # Test lambda function is still callable
         result = lambda_func(mock_sim)
         assert result == "lambda_result"
+
+    def test_float_interval_validation_valid(self, mock_sim):
+        """Test that valid float intervals are accepted."""
+        # Test valid float intervals (0 < interval < 1)
+        valid_intervals = [0.1, 0.5, 0.9, 0.001, 0.999]
+        
+        for interval in valid_intervals:
+            @callback(stage="start", interval=interval)
+            def test_func(sim):
+                return f"result_{interval}"
+            
+            # Should not raise any error
+            assert test_func.stage == "start"
+
+    def test_float_interval_validation_invalid(self, mock_sim):
+        """Test that invalid float intervals raise ValueError."""
+        # Test invalid float intervals
+        invalid_intervals = [0.0, 1.0, -0.1, 1.1, -1.0, 2.0]
+        
+        for interval in invalid_intervals:
+            with pytest.raises(ValueError, match=f"Invalid interval: {interval}"):
+                @callback(stage="start", interval=interval)
+                def test_func(sim):
+                    pass
+
+    def test_float_interval_execution_logic(self, mock_sim_with_time):
+        """Test the execution logic for float intervals."""
+        executed = []
+        
+        @callback(stage="start", interval=0.5)
+        def test_func(sim):
+            executed.append(sim.time)
+            return "executed"
+        
+        # Test at different time points
+        test_cases = [
+            (0.0, True),     # time=0.0, should execute (0.0 % 0.5 = 0.0 > 0.1? False → execute)
+            (0.4, False),    # time=0.4, should not execute (0.4 % 0.5 = 0.4 > 0.1? True → not execute)
+            (0.49, False),   # time=0.49, should not execute (0.49 % 0.5 = 0.49 > 0.1? True → not execute)
+            (0.5, True),     # time=0.5, should execute (0.5 % 0.5 = 0.0 > 0.1? False → execute)
+            (1.0, True),     # time=1.0, should execute (1.0 % 0.5 = 0.0 > 0.1? False → execute)
+            (1.4, False),    # time=1.4, should not execute (1.4 % 0.5 = 0.4 > 0.1? True → not execute)
+        ]
+        
+        for time, should_execute in test_cases:
+            mock_sim_with_time.time = time
+            executed.clear()
+            result = test_func(mock_sim_with_time)
+            
+            if should_execute:
+                assert len(executed) == 1
+                assert executed[0] == time
+                assert result == "executed"
+            else:
+                assert len(executed) == 0
+                assert result is None
+
+    def test_float_interval_boundary_cases(self, mock_sim):
+        """Test boundary cases for float intervals."""
+        # Test very small interval (close to 0) - should be valid
+        @callback(stage="start", interval=0.0001)
+        def test_func1(sim):
+            pass
+        assert test_func1.stage == "start"
+        
+        # Test interval very close to 1 - should be valid
+        @callback(stage="start", interval=0.9999)
+        def test_func2(sim):
+            pass
+        assert test_func2.stage == "start"
+        
+        # Test exactly 0 - should raise error
+        with pytest.raises(ValueError, match="Invalid interval: 0.0"):
+            @callback(stage="start", interval=0.0)
+            def test_func3(sim):
+                pass
+        
+        # Test exactly 1 - should raise error
+        with pytest.raises(ValueError, match="Invalid interval: 1.0"):
+            @callback(stage="start", interval=1.0)
+            def test_func4(sim):
+                pass
+
+    def test_callback_class_float_interval(self, mock_sim_with_time):
+        """Test that Callback class handles float intervals correctly."""
+        from lambdapic.callback.callback import Callback
+        
+        class TestCallback(Callback):
+            def __init__(self, interval):
+                self.interval = interval
+                self.stage = "start"
+            
+            def _call(self, sim):
+                return None
+        
+        # Test valid float interval
+        callback = TestCallback(0.5)
+        mock_sim_with_time.time = 0.5  # Should execute at this time
+        result = callback(mock_sim_with_time)
+        assert result is None  # Callback.__call__ returns None
+        
+        # Test invalid float interval should raise ValueError when called
+        invalid_callback = TestCallback(1.0)
+        with pytest.raises(ValueError, match="Invalid interval: 1.0"):
+            invalid_callback(mock_sim_with_time)


### PR DESCRIPTION
## Summary

This PR adds support for float intervals in callback functions, enabling time-based execution control alongside the existing step-based intervals.

## Changes

- **Enhanced callback decorator**: Now accepts float values for interval parameter (0 < interval < 1)
- **Time-based execution**: When using float intervals, callbacks execute based on simulation time rather than step count
- **Validation**: Added comprehensive validation for float interval values
- **Testing**: Added extensive unit tests covering validation and execution logic

## Usage

```python
# Time-based callback - executes every 0.5 seconds of simulation time
@callback(stage="maxwell first", interval=0.5)
def field_modification(sim):
    # Modify fields based on simulation time
    pass

# Step-based callback (existing) - executes every 100 steps  
@callback(stage="maxwell first", interval=100)
def step_based_callback(sim):
    pass
```

## Technical Details

- Float intervals must be between 0 and 1 (exclusive)
- Execution logic: sim.time % interval >= sim.dt determines when to skip execution
- Backward compatible - existing integer intervals continue to work unchanged
- Added comprehensive test coverage for edge cases and boundary conditions

## Files Modified

- src/lambdapic/callback/callback.py - Main implementation
- src/lambdapic/callback/hdf5.py - Updated usage
- src/lambdapic/callback/plot.py - Updated usage  
- src/lambdapic/callback/utils.py - Updated usage
- tests/test_callback.py - Added comprehensive tests
- example/laser-target.py - Example usage