### PR TITLE
refactor: replace pairing generators with pairing iterators

### DIFF
--- a/tests/test_inter_collision_cell.py
+++ b/tests/test_inter_collision_cell.py
@@ -13,6 +13,7 @@ dt = 1e-15
 def create_random_particles(n_particles: int,
                             mass: float = m_e,
                             charge: float = -e,
+                            dead_fraction: float = 0.0,
                             seed: int = 1234) -> ParticleData:
     """Create a ParticleData with random momenta and consistent inv_gamma."""
     rng = np.random.default_rng(seed)
@@ -33,9 +34,9 @@ def create_random_particles(n_particles: int,
     # inv_gamma = 1/sqrt(1+u^2)
     particles.inv_gamma[:] = 1.0 / np.sqrt(1.0 + u2)
 
-    # unit weights, all alive
+    # unit weights
     particles.w[:] = 1e29 * cell_vol / n_particles
-    particles.is_dead[:] = False
+    particles.is_dead[:] = np.random.uniform(size=n_particles) < dead_fraction
 
     return ParticleData(
         x=particles.x, y=particles.y, z=particles.z,
@@ -58,11 +59,16 @@ def assert_no_nans_particle_data(p: ParticleData):
         assert np.all(np.isfinite(arr))
 
 
+@pytest.fixture(params=[0.0, 0.2, 1.0])
+def dead_fraction(request):
+    return request.param
+
+
 @pytest.mark.parametrize("n1, n2", [(8, 128), (128, 128), (1024, 128)])
-def test_inter_collision_cell_lnLambda0_no_nan(n1, n2):
+def test_inter_collision_cell_lnLambda0_no_nan(n1, n2, dead_fraction):
     # Two species with identical mass/charge to avoid asymmetry issues
-    part1 = create_random_particles(n1, mass=m_e, charge=-e, seed=1)
-    part2 = create_random_particles(n2, mass=m_e, charge=-e, seed=2)
+    part1 = create_random_particles(n1, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=1)
+    part2 = create_random_particles(n2, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=2)
 
     # Bounds cover all particles in a single cell for each species
     ip_start1, ip_end1 = 0, n1
@@ -85,9 +91,9 @@ def test_inter_collision_cell_lnLambda0_no_nan(n1, n2):
     assert_no_nans_particle_data(part2)
 
 @pytest.mark.parametrize("n1, n2", [(8, 128), (128, 128), (1024, 128)])
-def test_inter_collision_energy_conservation(n1, n2):
-    part1 = create_random_particles(n1, mass=m_e, charge=-e, seed=101)
-    part2 = create_random_particles(n2, mass=m_e, charge=-e, seed=202)
+def test_inter_collision_energy_conservation(n1, n2, dead_fraction):
+    part1 = create_random_particles(n1, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=101)
+    part2 = create_random_particles(n2, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=202)
 
     ip_start1, ip_end1 = 0, n1
     ip_start2, ip_end2 = 0, n2
@@ -116,3 +122,80 @@ def test_inter_collision_energy_conservation(n1, n2):
 
     # Slightly looser tolerance for accumulation over many pairs
     assert np.isclose(E_before, E_after, rtol=1e-3, atol=0.0)
+
+
+def test_inter_collision_respects_dead_flags(dead_fraction):
+    # Use moderate sizes to ensure some pairs form when alive exist
+    n1, n2 = 256, 192
+    part1 = create_random_particles(n1, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=11)
+    part2 = create_random_particles(n2, mass=m_e, charge=-e, dead_fraction=dead_fraction, seed=22)
+
+    ip_start1, ip_end1 = 0, n1
+    ip_start2, ip_end2 = 0, n2
+
+    # Snapshot state of dead particles before collisions
+    dead1 = np.where(part1.is_dead)[0]
+    dead2 = np.where(part2.is_dead)[0]
+    ux1_d, uy1_d, uz1_d, ig1_d, w1_d = (
+        part1.ux[dead1].copy(), part1.uy[dead1].copy(), part1.uz[dead1].copy(),
+        part1.inv_gamma[dead1].copy(), part1.w[dead1].copy()
+    )
+    ux2_d, uy2_d, uz2_d, ig2_d, w2_d = (
+        part2.ux[dead2].copy(), part2.uy[dead2].copy(), part2.uz[dead2].copy(),
+        part2.inv_gamma[dead2].copy(), part2.w[dead2].copy()
+    )
+
+    rng = np.random.default_rng(7)
+    debye_inv = 0.0
+    inter_collision_cell(
+        part1, ip_start1, ip_end1,
+        part2, ip_start2, ip_end2,
+        2.0, debye_inv,
+        cell_vol, dt,
+        rng,
+    )
+
+    # Dead particles must be unchanged by collisions
+    assert np.array_equal(part1.ux[dead1], ux1_d)
+    assert np.array_equal(part1.uy[dead1], uy1_d)
+    assert np.array_equal(part1.uz[dead1], uz1_d)
+    assert np.array_equal(part1.inv_gamma[dead1], ig1_d)
+    assert np.array_equal(part1.w[dead1], w1_d)
+
+    assert np.array_equal(part2.ux[dead2], ux2_d)
+    assert np.array_equal(part2.uy[dead2], uy2_d)
+    assert np.array_equal(part2.uz[dead2], uz2_d)
+    assert np.array_equal(part2.inv_gamma[dead2], ig2_d)
+    assert np.array_equal(part2.w[dead2], w2_d)
+
+    # General sanity: no NaNs anywhere
+    assert_no_nans_particle_data(part1)
+    assert_no_nans_particle_data(part2)
+
+
+def test_inter_collision_alters_momentum():
+    # Ensure all alive to test that momentum changes occur
+    n1, n2 = 128, 192
+    part1 = create_random_particles(n1, mass=m_e, charge=-e, dead_fraction=0.0, seed=303)
+    part2 = create_random_particles(n2, mass=m_e, charge=-e, dead_fraction=0.0, seed=404)
+
+    ux1_0, uy1_0, uz1_0 = part1.ux.copy(), part1.uy.copy(), part1.uz.copy()
+    ux2_0, uy2_0, uz2_0 = part2.ux.copy(), part2.uy.copy(), part2.uz.copy()
+
+    ip_start1, ip_end1 = 0, n1
+    ip_start2, ip_end2 = 0, n2
+
+    debye_inv = 0.0
+    rng = np.random.default_rng(55)
+
+    inter_collision_cell(
+        part1, ip_start1, ip_end1,
+        part2, ip_start2, ip_end2,
+        2.0, debye_inv,
+        cell_vol, dt,
+        rng,
+    )
+
+    changed1 = not (np.allclose(part1.ux, ux1_0) and np.allclose(part1.uy, uy1_0) and np.allclose(part1.uz, uz1_0))
+    changed2 = not (np.allclose(part2.ux, ux2_0) and np.allclose(part2.uy, uy2_0) and np.allclose(part2.uz, uz2_0))
+    assert (changed1 or changed2), "Expected inter collisions to alter at least one species' momentum"

--- a/tests/test_intra_collision_cell.py
+++ b/tests/test_intra_collision_cell.py
@@ -94,7 +94,7 @@ def test_intra_collision_cell_no_nan(n):
 
     assert_no_nans_particle_data(part)
 
-
+@pytest.mark.parametrize("n", [8, 128, 1024])
 def test_intra_collision_energy_conservation(n):
     part = create_random_particles(n, mass=m_e, charge=-e, seed=101)
 


### PR DESCRIPTION
Summary
- Replaces intra/inter collision pairing generators with Numba jitclass iterators to centralize logic and simplify call sites.
- Preserves dt correction and weight correction semantics; improves readability and maintainability.

Key Changes
- Add IntraPairingIterator and InterPairingIterator encapsulating pairing logic and per‑pair corrections.
- Replace generator loops in intra_collision_cell and inter_collision_cell with iterator usage.
- Update tests to validate intra-collision stability and invariants (no NaNs, energy proxy).

Behavior and Semantics
- Intra: pairs live particles with odd/even handling; dt_corr = 2*npairs-1; first/last pair half weight for odd case.
- Inter: shuffles larger live side; cycles the other to avoid bias; dt_corr = npairs; weight correction matches prior distribution.
- Call sites scale dt by returned dt_corr and apply w_corr per pair as before.

Performance and Numba
- Pairing work moved into JIT-compiled classes to keep hot loops in nopython paths.
- Random shuffling performed once per iterator construction; pair iteration uses simple index advancement.

MPI/Determinism
- No MPI surface changes; pairing remains per cell/patch and uses the provided RNG instance.
- Determinism follows previous code paths given identical seeds and cell ordering.

Follow‑ups (if desired)
- [x] Expand tests to mixed dead-flag cases.
