### PR TITLE
Fix docstring escape sequences, alive particle counts for load balancing, and reproducible RNG

### DIFF
--- a/src/lambdapic/callback/laser.py
+++ b/src/lambdapic/callback/laser.py
@@ -360,7 +360,7 @@ class SimpleLaser3D(Laser3D, SimpleLaser):
 
 
 class GaussianLaser(Laser):
-    """
+    r"""
     Implementation of a proper Gaussian laser beam with full physics including:
     
     - Gaussian temporal and spatial profiles

--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -773,6 +773,7 @@ class SetTemperature(Callback):
 
     def _call(self, sim: Simulation) -> None:
         ispec = self.species.ispec
+        rand_gen, = sim.rand_gen.spawn(1)
         for p in sim.patches:
             part = p.particles[ispec]
             alive = part.is_alive
@@ -781,7 +782,7 @@ class SetTemperature(Callback):
                 continue
             
             thetax = self.temperature[0]*e / (self.species.m * c**2)
-            ux, uy, uz = self.sample_maxwell_juttner(n, thetax)
+            ux, uy, uz = self.sample_maxwell_juttner(n, thetax, rand_gen)
             # stretch to simulate temperature anisotropy
             part.ux[alive] = ux
             part.uy[alive] = uy * self.temperature[1]/self.temperature[0]
@@ -803,7 +804,7 @@ class SetTemperature(Callback):
         return (gamma**2 * beta) / (theta * k2) * np.exp(-gamma/theta)
     
     @staticmethod
-    def sample_maxwell_juttner(size: int, theta: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def sample_maxwell_juttner(size: int, theta: float, rand_gen: np.random.Generator|None=None) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Generate samples from Maxwell-Jüttner distribution
         Using a mixed strategy to adapt to different temperature ranges:
@@ -812,11 +813,12 @@ class SetTemperature(Callback):
         - θ > 0.5: Gamma proposal distribution + β acceptance probability
         """
         import scipy
+        rand_gen = rand_gen or np.random.default_rng()
         
         gamma = np.zeros(size)
         # Non-relativistic approximation (θ ≤ 0.01)
         if theta <= 0.01:
-            gamma[:] = scipy.stats.gamma(a=1.5, scale=theta).rvs(size=size) + 1
+            gamma[:] = scipy.stats.gamma(a=1.5, scale=theta).rvs(size=size, random_state=rand_gen) + 1
         
         # Medium temperature range (0.01 < θ ≤ 0.5)
         elif theta <= 0.5:
@@ -832,9 +834,9 @@ class SetTemperature(Callback):
             
             count: int = 0
             while count < size:
-                gamma_prop = np.random.uniform(1, gamma_max, size-count)
+                gamma_prop = rand_gen.uniform(1, gamma_max, size-count)
                 f_val = SetTemperature.maxwell_juttner_pdf(gamma_prop, theta)
-                accept = np.random.uniform(0, M, size-count) < f_val
+                accept = rand_gen.uniform(0, M, size-count) < f_val
                 gamma_accept = gamma_prop[accept]
                 n_accept = len(gamma_accept)
                 
@@ -846,9 +848,9 @@ class SetTemperature(Callback):
             gamma_dist = scipy.stats.gamma(a=3, scale=theta)
             count: int = 0
             while count < size:
-                gamma_prop = gamma_dist.rvs(size-count)
+                gamma_prop = gamma_dist.rvs(size-count, random_state=rand_gen)
                 beta_val = beta_val = np.sqrt(1 - 1/(np.ma.array(gamma_prop, mask=gamma_prop < 1)**2))
-                accept = (np.random.uniform(size=size-count) < beta_val) & (gamma_prop >= 1)
+                accept = (rand_gen.uniform(size=size-count) < beta_val) & (gamma_prop >= 1)
                 gamma_accept = gamma_prop[accept]
                 n_accept = len(gamma_accept)
                 
@@ -856,8 +858,8 @@ class SetTemperature(Callback):
                 count += n_accept
         
         u = np.sqrt(gamma**2 - 1)
-        phi = np.random.uniform(0, 2*np.pi, size)
-        costheta = np.random.uniform(-1, 1, size)
+        phi = rand_gen.uniform(0, 2*np.pi, size)
+        costheta = rand_gen.uniform(-1, 1, size)
         sintheta = np.sqrt(1 - costheta**2)
         ux = u * sintheta * np.cos(phi)
         uy = u * sintheta * np.sin(phi)

--- a/src/lambdapic/core/collision/cpu.py
+++ b/src/lambdapic/core/collision/cpu.py
@@ -249,7 +249,7 @@ def constrain_debye_length_patches(
 
 @njit(cache=True)
 def varying_lnLambda(d: CollisionData, debye_length_inv_square: np.float64|float) -> float:
-    """
+    r"""
     https://doi.org/10.1063/1.4742167
 
     typo square removed

--- a/src/lambdapic/core/mpi/load_balancer.py
+++ b/src/lambdapic/core/mpi/load_balancer.py
@@ -89,10 +89,7 @@ class LoadBalancer(EnableMixin):
         load = 0.0
 
         for part in patch.particles:
-            # npart_alive = (~patch.particles[ispec].is_dead).sum()
-
-            # TODO: calculate npart_alive in a Patches method
-            load += part.npart
+            load += part._npart_alive
 
         if hasattr(patch, 'nz'):
             load += patch.nx * patch.ny * patch.nz / 2

--- a/src/lambdapic/core/particles.py
+++ b/src/lambdapic/core/particles.py
@@ -52,6 +52,7 @@ class ParticlesBase:
 
     npart: int # length of the particles, including dead
     _npart_created: int  # counter for generating sequential local IDs
+    _npart_alive: int # updated on call of sync_particles(), not realtime
 
     def __init__(self, ipatch: Optional[int]=None, rank: Optional[int]=None) -> None:
         """
@@ -66,6 +67,7 @@ class ParticlesBase:
         ]
         self.extended: bool = False
         self._npart_created = 0
+        self._npart_alive = 0
 
         if rank is None:
             try:

--- a/src/lambdapic/core/patch/patch.py
+++ b/src/lambdapic/core/patch/patch.py
@@ -707,6 +707,8 @@ class Patches:
                     self.npatches, self.dx, self.dy,
                 )
                 npart_patches += _npart_patches
+                for ipatch, p in enumerate(self.patches):
+                    p.particles[ispec]._npart_alive = _npart_patches[ipatch]
 
                 # extend the particles in each patch in python mode
                 # TODO: extend the particles in each patch in numba mode in parallel
@@ -734,6 +736,8 @@ class Patches:
                     self.npatches, self.dx, self.dy, self.dz,
                 )
                 npart_patches += _npart_patches
+                for ipatch, p in enumerate(self.patches):
+                    p.particles[ispec]._npart_alive = _npart_patches[ipatch]
 
                 for ipatches in range(self.npatches):
                     p = self[ipatches].particles[ispec]


### PR DESCRIPTION
## Summary

This PR contains three fixes:

1. **Fix invalid escape sequence warnings** - Convert docstrings with LaTeX/math expressions to raw strings in `laser.py` and `cpu.py` to eliminate Python 3.12+ `SyntaxWarning`.

2. **Use alive particle counts for load balancing** - Track `_npart_alive` per species (updated during `sync_particles()`) and use it in the load balancer instead of total particle count. This ensures dead particles don't skew load calculations.

3. **Use spawned RNG for reproducibility** - Replace global `np.random` calls in `SetTemperature` callback with a spawned RNG from `sim.rand_gen`, ensuring reproducible results when using the same seed.

## Changes

- `src/lambdapic/callback/laser.py`: Raw docstring for LaTeX
- `src/lambdapic/core/collision/cpu.py`: Raw docstring for LaTeX
- `src/lambdapic/core/particles.py`: Add `_npart_alive` field
- `src/lambdapic/core/patch/patch.py`: Populate `_npart_alive` during sync
- `src/lambdapic/core/mpi/load_balancer.py`: Use `_npart_alive` for load calculation
- `src/lambdapic/callback/utils.py`: Spawn RNG and use throughout `sample_maxwell_juttner`
