### PR TITLE
feat(hdf5): add slice support to HDF5 callbacks

### DIFF
--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -35,11 +35,12 @@ class SaveFieldsToHDF5(Callback):
             Available: ['ex','ey','ez','bx','by','bz','jx','jy','jz','rho']. 
             If None, saves all components.
     """
-    stage="maxwell_2"
+    DEFAULT_STAGE = "end"
     def __init__(self, 
                  prefix: Union[str, Path]='', 
                  interval: Union[int, float, Callable] = 100,
                  components: Optional[List[str]] = None) -> None:
+        self.stage = self.DEFAULT_STAGE
         self.prefix = Path(prefix)
         self.interval = interval
 
@@ -379,12 +380,13 @@ class SaveParticlesToHDF5(Callback):
         attrs (Optional[List[str]], optional): List of particle attributes to save.
             If None, saves all attributes.
     """
-    stage="maxwell_2"
+    DEFAULT_STAGE = "end"
     def __init__(self,
                  species: Species,
                  prefix: Union[str, Path]='',
                  interval: Union[int, float, Callable] = 100,
                  attrs: Optional[List[str]] = None) -> None:
+        self.stage = self.DEFAULT_STAGE
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)
 

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -164,9 +164,8 @@ def _serialize_slice(normalized_slice: tuple, dims: tuple) -> str:
 class _HDF5SliceWriter:
     """Encapsulates parallel HDF5 write logic for multi-component field/density data with slice support."""
 
-    def __init__(self, mpi: bool, barrier_after_create: bool = False):
+    def __init__(self, mpi: bool):
         self.mpi = mpi
-        self.barrier_after_create = barrier_after_create
 
     def write(
         self,
@@ -218,8 +217,7 @@ class _HDF5SliceWriter:
         with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
             for comp in components:
                 dset = f.create_dataset(comp, data=np.zeros(shape, dtype='f8'), chunks=chunk_size)
-                if self.barrier_after_create:
-                    comm.Barrier()
+                comm.Barrier()
                 for ip, p in enumerate(sim.patches):
                     offsets = self._patch_offsets(p, sim, ndim)
                     slices_info = [
@@ -368,9 +366,10 @@ class SaveFieldsToHDF5(Callback):
                 f.attrs['itime'] = sim.itime
                 if self._normalized_slice is not None:
                     f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
+        comm.Barrier()
                 
     def _write_3d(self, sim: Simulation3D, filename: Path):
-        writer = _HDF5SliceWriter(mpi=self.mpi, barrier_after_create=True)
+        writer = _HDF5SliceWriter(mpi=self.mpi)
         writer.write(
             filename, sim, self.components,
             lambda ip, p, comp: getattr(p.fields, comp),
@@ -519,6 +518,7 @@ class SaveSpeciesDensityToHDF5(Callback):
                 f.attrs['Ly'] = sim.Ly
                 if self._normalized_slice is not None:
                     f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
+        comm.Barrier()
 
     def _write_3d(self, sim: Simulation3D, density_per_patch: List[np.ndarray], filename: Path):
         writer = _HDF5SliceWriter(mpi=self.mpi)
@@ -545,6 +545,7 @@ class SaveSpeciesDensityToHDF5(Callback):
                 f.attrs['Lz'] = sim.Lz
                 if self._normalized_slice is not None:
                     f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny, sim.nz))
+        comm.Barrier()
 
 class SaveParticlesToHDF5(Callback):
     """Callback to save particle data to HDF5 files.

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -12,6 +12,155 @@ from ..simulation import Simulation, Simulation3D
 from .callback import Callback
 
 
+def _normalize_slice(sim_dim: int, user_slice: tuple[int | slice, ...], dims: tuple) -> tuple[slice, ...] | None:
+    """Normalize a user-provided slice specification to full slice objects.
+
+    Converts ints to ``slice(i, i+1, 1)`` and ``slice(None)`` to ``slice(0, dim, 1)``.
+
+    Args:
+        sim_dim (int): Number of dimensions (2 or 3).
+        user_slice (tuple[int | slice, ...]): User-provided ``np.s_``-style slice tuple,
+            e.g. ``np.s_[:, :, 100]`` or ``np.s_[::2, ::2, ::5]``.
+        dims (tuple): Size of each dimension, e.g. ``(nx, ny)``.
+
+    Returns:
+        Optional[tuple]: Normalized tuple of ``slice`` objects, or ``None`` if
+            ``user_slice`` is ``None``.
+
+    Raises:
+        ValueError: If the slice specification contains invalid types, out-of-bounds
+            indices, or negative steps.
+    """
+    if user_slice is None:
+        return None
+    
+    # Wrap single slice or int in tuple
+    if isinstance(user_slice, (slice, int)):
+        user_slice = (user_slice,)
+    
+    # Reject Ellipsis
+    if any(isinstance(s, type(Ellipsis)) for s in user_slice):
+        raise ValueError("Ellipsis (...) is not supported in slice specification")
+    
+    # Reject None/np.newaxis
+    if any(s is None for s in user_slice):
+        raise ValueError("None/np.newaxis is not supported in slice specification")
+    
+    # Validate length
+    if len(user_slice) != sim_dim:
+        raise ValueError(
+            f"Slice tuple length {len(user_slice)} does not match "
+            f"simulation dimension {sim_dim}"
+        )
+    
+    result = []
+    for i, s in enumerate(user_slice):
+        dim = dims[i]
+        if isinstance(s, int):
+            # Normalize negative index
+            if s < 0:
+                s = dim + s
+            if s < 0 or s >= dim:
+                raise ValueError(
+                    f"Index {s} out of bounds for dimension {i} with size {dim}"
+                )
+            result.append(slice(s, s + 1, 1))
+        elif isinstance(s, slice):
+            start, stop, step = s.start, s.stop, s.step
+            # Fill defaults
+            if start is None:
+                start = 0
+            if stop is None:
+                stop = dim
+            if step is None:
+                step = 1
+            # Validate step
+            if step <= 0:
+                raise ValueError(f"Step must be positive, got {step}")
+            # Resolve negatives
+            if start < 0:
+                start = dim + start
+            if stop < 0:
+                stop = dim + stop
+            # Clamp to valid range
+            start = max(0, min(start, dim))
+            stop = max(0, min(stop, dim))
+            # Validate at least 1 element
+            if start >= stop:
+                raise ValueError(
+                    f"Slice {s} has no elements for dimension {i} with size {dim}"
+                )
+            result.append(slice(start, stop, step))
+        else:
+            raise ValueError(
+                f"Invalid slice element type: {type(s).__name__}. "
+                f"Expected int or slice."
+            )
+    
+    return tuple(result)
+
+
+def _compute_patch_slice(axis_dim: int, global_slice: slice,
+                         patch_offset: int, patch_size: int) -> Optional[tuple]:
+    """Compute the local slice for a single patch along one axis.
+
+    Determines which elements of a patch are selected by a global slice.
+
+    Args:
+        axis_dim (int): Total size of this axis (e.g., ``sim.nx``).
+        global_slice (slice): Normalized slice for this axis (start, stop, step).
+        patch_offset (int): Global offset of this patch (``ipatch * n_per_patch``).
+        patch_size (int): Size of this patch (``n_per_patch``).
+
+    Returns:
+        Optional[tuple]: ``(local_slice, output_start, num_elements)`` or ``None``
+            if the patch does not intersect the slice.
+    """
+    start, stop, step = global_slice.start, global_slice.stop, global_slice.step
+    offset, size = patch_offset, patch_size
+    
+    first = start + math.ceil(max(0, offset - start) / step) * step
+    last_global_in_patch = min(stop, offset + size) - 1
+    last_selected = start + math.floor((last_global_in_patch - start) / step) * step
+    
+    if last_selected < first:
+        return None
+    
+    local_first = first - offset
+    output_start = (first - start) // step
+    num = (last_selected - first) // step + 1
+    local_slice = slice(local_first, local_first + num * step, step)
+    
+    return (local_slice, output_start, num)
+
+
+def _serialize_slice(normalized_slice: tuple, dims: tuple) -> str:
+    """Convert a normalized slice tuple to a human-readable string.
+
+    Args:
+        normalized_slice (tuple): Normalized tuple of ``slice`` objects.
+        dims (tuple): Full size of each axis in the simulation domain.
+
+    Returns:
+        str: Human-readable string such as ``"[:, :, 100]"``.
+    """
+    parts = []
+    for s, dim in zip(normalized_slice, dims):
+        if s.start == 0 and s.stop == dim and s.step == 1:
+            parts.append(":")
+        elif s.step == 1 and s.stop == s.start + 1:
+            # Single element like slice(i, i+1, 1) -> "i"
+            parts.append(str(s.start))
+        else:
+            start = "" if s.start == 0 else str(s.start)
+            stop = "" if s.stop == dim else str(s.stop)
+            if s.step == 1:
+                parts.append(f"{start}:{stop}")
+            else:
+                parts.append(f"{start}:{stop}:{s.step}")
+    return "[" + ", ".join(parts) + "]"
+
+
 class SaveFieldsToHDF5(Callback):
     """Callback to save field data to HDF5 files.
 
@@ -74,9 +223,9 @@ class SaveFieldsToHDF5(Callback):
         # Normalize np.s_-style slice input to explicit slice objects
         if self.slice is not None:
             if sim.dimension == 2:
-                self._normalized_slice = self._normalize_slice(2, self.slice, (sim.nx, sim.ny))
+                self._normalized_slice = _normalize_slice(2, self.slice, (sim.nx, sim.ny))
             elif sim.dimension == 3:
-                self._normalized_slice = self._normalize_slice(3, self.slice, (sim.nx, sim.ny, sim.nz))
+                self._normalized_slice = _normalize_slice(3, self.slice, (sim.nx, sim.ny, sim.nz))
         else:
             self._normalized_slice = None
         filename = self.prefix / f"{sim.itime:06d}.h5"
@@ -84,156 +233,7 @@ class SaveFieldsToHDF5(Callback):
             self._write_2d(sim, filename)
         elif sim.dimension == 3:
             self._write_3d(sim, filename)
-        
-    @staticmethod
-    def _normalize_slice(sim_dim: int, user_slice: tuple[int | slice, ...], dims: tuple) -> tuple[slice, ...] | None:
-        """Normalize a user-provided slice specification to full slice objects.
 
-        Converts ints to ``slice(i, i+1, 1)`` and ``slice(None)`` to ``slice(0, dim, 1)``.
-
-        Args:
-            sim_dim (int): Number of dimensions (2 or 3).
-            user_slice (tuple[int | slice, ...]): User-provided ``np.s_``-style slice tuple,
-                e.g. ``np.s_[:, :, 100]`` or ``np.s_[::2, ::2, ::5]``.
-            dims (tuple): Size of each dimension, e.g. ``(nx, ny)``.
-
-        Returns:
-            Optional[tuple]: Normalized tuple of ``slice`` objects, or ``None`` if
-                ``user_slice`` is ``None``.
-
-        Raises:
-            ValueError: If the slice specification contains invalid types, out-of-bounds
-                indices, or negative steps.
-        """
-        if user_slice is None:
-            return None
-        
-        # Wrap single slice or int in tuple
-        if isinstance(user_slice, (slice, int)):
-            user_slice = (user_slice,)
-        
-        # Reject Ellipsis
-        if any(isinstance(s, type(Ellipsis)) for s in user_slice):
-            raise ValueError("Ellipsis (...) is not supported in slice specification")
-        
-        # Reject None/np.newaxis
-        if any(s is None for s in user_slice):
-            raise ValueError("None/np.newaxis is not supported in slice specification")
-        
-        # Validate length
-        if len(user_slice) != sim_dim:
-            raise ValueError(
-                f"Slice tuple length {len(user_slice)} does not match "
-                f"simulation dimension {sim_dim}"
-            )
-        
-        result = []
-        for i, s in enumerate(user_slice):
-            dim = dims[i]
-            if isinstance(s, int):
-                # Normalize negative index
-                if s < 0:
-                    s = dim + s
-                if s < 0 or s >= dim:
-                    raise ValueError(
-                        f"Index {s} out of bounds for dimension {i} with size {dim}"
-                    )
-                result.append(slice(s, s + 1, 1))
-            elif isinstance(s, slice):
-                start, stop, step = s.start, s.stop, s.step
-                # Fill defaults
-                if start is None:
-                    start = 0
-                if stop is None:
-                    stop = dim
-                if step is None:
-                    step = 1
-                # Validate step
-                if step <= 0:
-                    raise ValueError(f"Step must be positive, got {step}")
-                # Resolve negatives
-                if start < 0:
-                    start = dim + start
-                if stop < 0:
-                    stop = dim + stop
-                # Clamp to valid range
-                start = max(0, min(start, dim))
-                stop = max(0, min(stop, dim))
-                # Validate at least 1 element
-                if start >= stop:
-                    raise ValueError(
-                        f"Slice {s} has no elements for dimension {i} with size {dim}"
-                    )
-                result.append(slice(start, stop, step))
-            else:
-                raise ValueError(
-                    f"Invalid slice element type: {type(s).__name__}. "
-                    f"Expected int or slice."
-                )
-        
-        return tuple(result)
-    
-    @staticmethod
-    def _compute_patch_slice(axis_dim: int, global_slice: slice,
-                             patch_offset: int, patch_size: int) -> Optional[tuple]:
-        """Compute the local slice for a single patch along one axis.
-
-        Determines which elements of a patch are selected by a global slice.
-
-        Args:
-            axis_dim (int): Total size of this axis (e.g., ``sim.nx``).
-            global_slice (slice): Normalized slice for this axis (start, stop, step).
-            patch_offset (int): Global offset of this patch (``ipatch * n_per_patch``).
-            patch_size (int): Size of this patch (``n_per_patch``).
-
-        Returns:
-            Optional[tuple]: ``(local_slice, output_start, num_elements)`` or ``None``
-                if the patch does not intersect the slice.
-        """
-        start, stop, step = global_slice.start, global_slice.stop, global_slice.step
-        offset, size = patch_offset, patch_size
-        
-        first = start + math.ceil(max(0, offset - start) / step) * step
-        last_global_in_patch = min(stop, offset + size) - 1
-        last_selected = start + math.floor((last_global_in_patch - start) / step) * step
-        
-        if last_selected < first:
-            return None
-        
-        local_first = first - offset
-        output_start = (first - start) // step
-        num = (last_selected - first) // step + 1
-        local_slice = slice(local_first, local_first + num * step, step)
-        
-        return (local_slice, output_start, num)
-    
-    @staticmethod
-    def _serialize_slice(normalized_slice: tuple, dims: tuple) -> str:
-        """Convert a normalized slice tuple to a human-readable string.
-
-        Args:
-            normalized_slice (tuple): Normalized tuple of ``slice`` objects.
-            dims (tuple): Full size of each axis in the simulation domain.
-
-        Returns:
-            str: Human-readable string such as ``"[:, :, 100]"``.
-        """
-        parts = []
-        for s, dim in zip(normalized_slice, dims):
-            if s.start == 0 and s.stop == dim and s.step == 1:
-                parts.append(":")
-            elif s.step == 1 and s.stop == s.start + 1:
-                # Single element like slice(i, i+1, 1) -> "i"
-                parts.append(str(s.start))
-            else:
-                start = "" if s.start == 0 else str(s.start)
-                stop = "" if s.stop == dim else str(s.stop)
-                if s.step == 1:
-                    parts.append(f"{start}:{stop}")
-                else:
-                    parts.append(f"{start}:{stop}:{s.step}")
-        return "[" + ", ".join(parts) + "]"
-    
     def _write_2d(self, sim: Simulation, filename: Path):
         """Write 2D field data to HDF5 file in parallel.
 
@@ -267,8 +267,8 @@ class SaveFieldsToHDF5(Callback):
                         for p in sim.patches:
                             px = p.ipatch_x * sim.nx_per_patch
                             py = p.ipatch_y * sim.ny_per_patch
-                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
                             if x_info is None or y_info is None:
                                 continue
                             local_x, out_x, num_x = x_info
@@ -310,8 +310,8 @@ class SaveFieldsToHDF5(Callback):
                         for p in sim.patches:
                             px = p.ipatch_x * sim.nx_per_patch
                             py = p.ipatch_y * sim.ny_per_patch
-                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
                             if x_info is None or y_info is None:
                                 continue
                             local_x, out_x, num_x = x_info
@@ -353,7 +353,7 @@ class SaveFieldsToHDF5(Callback):
                 f.attrs['time'] = sim.time
                 f.attrs['itime'] = sim.itime
                 if self._normalized_slice is not None:
-                    f.attrs['slice'] = self._serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
+                    f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
                 
     def _write_3d(self, sim: Simulation3D, filename: Path):
         """Write 3D field data to HDF5 file in parallel.
@@ -390,9 +390,9 @@ class SaveFieldsToHDF5(Callback):
                             px = p.ipatch_x * sim.nx_per_patch
                             py = p.ipatch_y * sim.ny_per_patch
                             pz = p.ipatch_z * sim.nz_per_patch
-                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            z_info = self._compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
                             if x_info is None or y_info is None or z_info is None:
                                 continue
                             local_x, out_x, num_x = x_info
@@ -438,9 +438,9 @@ class SaveFieldsToHDF5(Callback):
                             px = p.ipatch_x * sim.nx_per_patch
                             py = p.ipatch_y * sim.ny_per_patch
                             pz = p.ipatch_z * sim.nz_per_patch
-                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            z_info = self._compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
                             if x_info is None or y_info is None or z_info is None:
                                 continue
                             local_x, out_x, num_x = x_info
@@ -486,7 +486,7 @@ class SaveFieldsToHDF5(Callback):
                 f.attrs['time'] = sim.time
                 f.attrs['itime'] = sim.itime
                 if self._normalized_slice is not None:
-                    f.attrs['slice'] = self._serialize_slice(self._normalized_slice, (sim.nx, sim.ny, sim.nz))
+                    f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny, sim.nz))
         comm.Barrier()
 
 
@@ -508,9 +508,13 @@ class SaveSpeciesDensityToHDF5(Callback):
         prefix (str): Prefix for output filenames. For example, if prefix is 'output', the files will be named 'output/{species.name}_000100.h5', 'output/{species.name}_000200.h5', etc.
         interval (Union[int, float, Callable], optional): Number of timesteps between saves, or a 
             function(sim) -> bool that determines when to save. Defaults to 100.
+        slice (tuple[int | slice, ...] | None, optional): Subset of the domain to save, specified via
+            ``np.s_`` indexing (e.g., ``slice=np.s_[:, :, 100]``, ``slice=np.s_[::2, ::2, ::5]``,
+            ``slice=np.s_[500:, :, :]``). Accepts any ``np.s_``-style tuple of ints and/or slices.
+            If None, saves the full domain. Defaults to None.
     """
     stage = "current_deposition"
-    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100, mpi: bool = False):
+    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100, mpi: bool = False, slice: tuple[int | slice, ...] | None = None):
         self.species = species
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)
@@ -519,6 +523,8 @@ class SaveSpeciesDensityToHDF5(Callback):
         self.interval = interval
         self.prev_rho = None
         self.species = species
+        self.slice = slice
+        self._normalized_slice = None
         os.makedirs(os.path.dirname(os.path.abspath(prefix)), exist_ok=True)
 
     @property
@@ -534,6 +540,14 @@ class SaveSpeciesDensityToHDF5(Callback):
         return self.species.ispec
         
     def _call(self, sim: Union[Simulation, Simulation3D]):
+        # Normalize np.s_-style slice input to explicit slice objects
+        if self.slice is not None:
+            if sim.dimension == 2:
+                self._normalized_slice = _normalize_slice(2, self.slice, (sim.nx, sim.ny))
+            elif sim.dimension == 3:
+                self._normalized_slice = _normalize_slice(3, self.slice, (sim.nx, sim.ny, sim.nz))
+        else:
+            self._normalized_slice = None
         filename = self.prefix / f"{self.species.name}_{sim.itime:06d}.h5"
             
         if self.ispec_target == 0:
@@ -592,34 +606,85 @@ class SaveSpeciesDensityToHDF5(Callback):
         comm = sim.mpi.comm
         rank = comm.Get_rank()
 
+        chunk_size = (sim.nx_per_patch, sim.ny_per_patch)
         if self.mpi:
-            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                dset = f.create_dataset(
-                    'density', 
-                    data=np.zeros((sim.nx, sim.ny), dtype='f8'),
-                    chunks=(sim.nx_per_patch, sim.ny_per_patch)
-                )
-                for ip, p in enumerate(sim.patches):
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                    dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
-        else:
-            if rank == 0:
-                with h5py.File(filename, 'w') as f:
+            if self._normalized_slice is not None:
+                sx, sy = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                     dset = f.create_dataset(
-                        'density', 
-                        data=np.zeros((sim.nx, sim.ny), dtype='f8'),
-                        chunks=(sim.nx_per_patch, sim.ny_per_patch)
+                        'density',
+                        data=np.zeros(shape, dtype='f8'),
+                        dtype='f8',
+                        chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
                     )
-            comm.Barrier()
+                    for ip, p in enumerate(sim.patches):
+                        px = p.ipatch_x * sim.nx_per_patch
+                        py = p.ipatch_y * sim.ny_per_patch
+                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                        if x_info is None or y_info is None:
+                            continue
+                        local_x, out_x, num_x = x_info
+                        local_y, out_y, num_y = y_info
+                        data = density_per_patch[ip][local_x, local_y]
+                        dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
+            else:
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
+                    dset = f.create_dataset(
+                        'density',
+                        data=np.zeros((sim.nx, sim.ny), dtype='f8'),
+                        chunks=chunk_size
+                    )
+                    for ip, p in enumerate(sim.patches):
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                        dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
+        else:
+            if self._normalized_slice is not None:
+                sx, sy = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        dset = f.create_dataset(
+                            'density',
+                            data=np.zeros(shape, dtype='f8'),
+                            dtype='f8',
+                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                        )
+                comm.Barrier()
 
-            with h5py.File(filename, 'a', locking=False) as f:
-                dset = f['density']
-                for ip, p in enumerate(sim.patches):
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                    dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
-            comm.Barrier()
+                with h5py.File(filename, 'a', locking=False) as f:
+                    dset = f['density']
+                    for ip, p in enumerate(sim.patches):
+                        px = p.ipatch_x * sim.nx_per_patch
+                        py = p.ipatch_y * sim.ny_per_patch
+                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                        if x_info is None or y_info is None:
+                            continue
+                        local_x, out_x, num_x = x_info
+                        local_y, out_y, num_y = y_info
+                        data = density_per_patch[ip][local_x, local_y]
+                        dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
+                comm.Barrier()
+            else:
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        dset = f.create_dataset(
+                            'density',
+                            data=np.zeros((sim.nx, sim.ny), dtype='f8'),
+                            chunks=chunk_size
+                        )
+                comm.Barrier()
+
+                with h5py.File(filename, 'a', locking=False) as f:
+                    dset = f['density']
+                    for ip, p in enumerate(sim.patches):
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                        dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
+                comm.Barrier()
 
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -632,6 +697,8 @@ class SaveSpeciesDensityToHDF5(Callback):
                 f.attrs['dy'] = sim.dy
                 f.attrs['Lx'] = sim.Lx
                 f.attrs['Ly'] = sim.Ly
+                if self._normalized_slice is not None:
+                    f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
 
     def _write_3d(self, sim: Simulation3D, density_per_patch: List[np.ndarray], filename: Path):
         """Write 3D density data to HDF5 file in parallel.
@@ -648,37 +715,93 @@ class SaveSpeciesDensityToHDF5(Callback):
         comm = sim.mpi.comm
         rank = comm.Get_rank()
 
+        chunk_size = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
         if self.mpi:
-            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                dset = f.create_dataset(
-                    'density', 
-                    data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
-                    dtype='f8',
-                    chunks=(sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
-                )
-
-                for ip, p in enumerate(sim.patches):
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                    dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        else:
-            if rank == 0:
-                with h5py.File(filename, 'w') as f:
+            if self._normalized_slice is not None:
+                sx, sy, sz = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                     dset = f.create_dataset(
-                        'density', 
+                        'density',
+                        data=np.zeros(shape, dtype='f8'),
+                        dtype='f8',
+                        chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                    )
+                    for ip, p in enumerate(sim.patches):
+                        px = p.ipatch_x * sim.nx_per_patch
+                        py = p.ipatch_y * sim.ny_per_patch
+                        pz = p.ipatch_z * sim.nz_per_patch
+                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                        z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                        if x_info is None or y_info is None or z_info is None:
+                            continue
+                        local_x, out_x, num_x = x_info
+                        local_y, out_y, num_y = y_info
+                        local_z, out_z, num_z = z_info
+                        data = density_per_patch[ip][local_x, local_y, local_z]
+                        dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+            else:
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
+                    dset = f.create_dataset(
+                        'density',
                         data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
                         dtype='f8',
-                        chunks=(sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
+                        chunks=chunk_size
                     )
-            comm.Barrier()
+                    for ip, p in enumerate(sim.patches):
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        else:
+            if self._normalized_slice is not None:
+                sx, sy, sz = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        dset = f.create_dataset(
+                            'density',
+                            data=np.zeros(shape, dtype='f8'),
+                            dtype='f8',
+                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                        )
+                comm.Barrier()
 
-            with h5py.File(filename, 'a', locking=False) as f:
-                dset = f['density']
-                for ip, p in enumerate(sim.patches):
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                    dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-            comm.Barrier()
+                with h5py.File(filename, 'a', locking=False) as f:
+                    dset = f['density']
+                    for ip, p in enumerate(sim.patches):
+                        px = p.ipatch_x * sim.nx_per_patch
+                        py = p.ipatch_y * sim.ny_per_patch
+                        pz = p.ipatch_z * sim.nz_per_patch
+                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                        z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                        if x_info is None or y_info is None or z_info is None:
+                            continue
+                        local_x, out_x, num_x = x_info
+                        local_y, out_y, num_y = y_info
+                        local_z, out_z, num_z = z_info
+                        data = density_per_patch[ip][local_x, local_y, local_z]
+                        dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+                comm.Barrier()
+            else:
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        dset = f.create_dataset(
+                            'density',
+                            data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
+                            dtype='f8',
+                            chunks=chunk_size
+                        )
+                comm.Barrier()
+
+                with h5py.File(filename, 'a', locking=False) as f:
+                    dset = f['density']
+                    for ip, p in enumerate(sim.patches):
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+                comm.Barrier()
 
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -694,8 +817,8 @@ class SaveSpeciesDensityToHDF5(Callback):
                 f.attrs['Lx'] = sim.Lx
                 f.attrs['Ly'] = sim.Ly
                 f.attrs['Lz'] = sim.Lz
-
-        comm.Barrier()
+                if self._normalized_slice is not None:
+                    f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny, sim.nz))
 
 class SaveParticlesToHDF5(Callback):
     """Callback to save particle data to HDF5 files.

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -161,6 +161,119 @@ def _serialize_slice(normalized_slice: tuple, dims: tuple) -> str:
     return "[" + ", ".join(parts) + "]"
 
 
+class _HDF5SliceWriter:
+    """Encapsulates parallel HDF5 write logic for multi-component field/density data with slice support."""
+
+    def __init__(self, mpi: bool, barrier_after_create: bool = False):
+        self.mpi = mpi
+        self.barrier_after_create = barrier_after_create
+
+    def write(
+        self,
+        filename: Path,
+        sim,
+        components: list[str],
+        patch_data_fn: Callable[[int, object, str], np.ndarray],
+        normalized_slice: tuple[slice, ...] | None,
+    ):
+        """Write multi-component data to HDF5, handling 2D/3D, MPI/non-MPI, and optional slicing."""
+        if sim.dimension == 2:
+            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 2)
+        elif sim.dimension == 3:
+            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 3)
+
+    def _write_nd(
+        self,
+        filename: Path,
+        sim,
+        components: list[str],
+        patch_data_fn: Callable[[int, object, str], np.ndarray],
+        normalized_slice: tuple[slice, ...] | None,
+        ndim: int,
+    ):
+        comm = sim.mpi.comm
+        rank = comm.Get_rank()
+
+        if ndim == 2:
+            dims = (sim.nx, sim.ny)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch)
+        else:
+            dims = (sim.nx, sim.ny, sim.nz)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
+
+        if normalized_slice is None:
+            normalized_slice = tuple(slice(0, d, 1) for d in dims)
+
+        shape = tuple(len(range(s.start, s.stop, s.step)) for s in normalized_slice)
+        chunk_size = tuple(min(c, s) for c, s in zip(per_patch, shape))
+
+        if self.mpi:
+            self._write_mpi(filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size)
+        else:
+            self._write_non_mpi(filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size)
+
+    def _write_mpi(
+        self, filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size,
+    ):
+        with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
+            for comp in components:
+                dset = f.create_dataset(comp, data=np.zeros(shape, dtype='f8'), chunks=chunk_size)
+                if self.barrier_after_create:
+                    comm.Barrier()
+                for ip, p in enumerate(sim.patches):
+                    offsets = self._patch_offsets(p, sim, ndim)
+                    slices_info = [
+                        _compute_patch_slice(d, s, o, pp)
+                        for d, s, o, pp in zip(dims, normalized_slice, offsets, per_patch)
+                    ]
+                    if any(si is None for si in slices_info):
+                        continue
+                    local_slices = [si[0] for si in slices_info]
+                    out_starts = [si[1] for si in slices_info]
+                    nums = [si[2] for si in slices_info]
+
+                    data = patch_data_fn(ip, p, comp)
+                    data = data[tuple(local_slices)]
+                    out_idx = tuple(slice(o, o + n) for o, n in zip(out_starts, nums))
+                    dset[out_idx] = data
+
+    def _write_non_mpi(
+        self, filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size,
+    ):
+        if rank == 0:
+            with h5py.File(filename, 'w') as f:
+                for comp in components:
+                    f.create_dataset(comp, data=np.zeros(shape, dtype='f8'), chunks=chunk_size)
+        comm.Barrier()
+
+        with h5py.File(filename, 'a', locking=False) as f:
+            for comp in components:
+                dset = f[comp]
+                for ip, p in enumerate(sim.patches):
+                    offsets = self._patch_offsets(p, sim, ndim)
+                    slices_info = [
+                        _compute_patch_slice(d, s, o, pp)
+                        for d, s, o, pp in zip(dims, normalized_slice, offsets, per_patch)
+                    ]
+                    if any(si is None for si in slices_info):
+                        continue
+                    local_slices = [si[0] for si in slices_info]
+                    out_starts = [si[1] for si in slices_info]
+                    nums = [si[2] for si in slices_info]
+
+                    data = patch_data_fn(ip, p, comp)
+                    data = data[tuple(local_slices)]
+                    out_idx = tuple(slice(o, o + n) for o, n in zip(out_starts, nums))
+                    dset[out_idx] = data
+        comm.Barrier()
+
+    @staticmethod
+    def _patch_offsets(p, sim, ndim: int):
+        if ndim == 2:
+            return (p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch)
+        return (p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch)
+
+
 class SaveFieldsToHDF5(Callback):
     """Callback to save field data to HDF5 files.
 
@@ -235,113 +348,14 @@ class SaveFieldsToHDF5(Callback):
             self._write_3d(sim, filename)
 
     def _write_2d(self, sim: Simulation, filename: Path):
-        """Write 2D field data to HDF5 file in parallel.
-
-        Args:
-            sim (Simulation): 2D simulation object containing field data
-            filename (str): Output HDF5 filename
-
-        Note:
-            - Creates HDF5 file with datasets for each field component
-            - Uses MPI parallel I/O to write patch data
-            - Includes simulation metadata as file attributes
-        """
-        # Get MPI communicator
+        writer = _HDF5SliceWriter(mpi=self.mpi)
+        writer.write(
+            filename, sim, self.components,
+            lambda ip, p, comp: getattr(p.fields, comp),
+            self._normalized_slice,
+        )
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-        
-        chunk_size = (sim.nx_per_patch, sim.ny_per_patch)
-        # Create filename with timestep
-        if self.mpi:
-            if self._normalized_slice is not None:
-                sx, sy = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    for field in self.components:
-                        dset = f.create_dataset(
-                            field, 
-                            data=np.zeros(shape),
-                            dtype='f8',
-                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                        )
-                        for p in sim.patches:
-                            px = p.ipatch_x * sim.nx_per_patch
-                            py = p.ipatch_y * sim.ny_per_patch
-                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            if x_info is None or y_info is None:
-                                continue
-                            local_x, out_x, num_x = x_info
-                            local_y, out_y, num_y = y_info
-                            data = getattr(p.fields, field)[local_x, local_y]
-                            dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
-            else:
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    for field in self.components:
-                        dset = f.create_dataset(
-                            field, 
-                            data=np.zeros((sim.nx, sim.ny)),
-                            dtype='f8',
-                            chunks=chunk_size
-                        )
-                        for p in sim.patches:
-                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                            data = getattr(p.fields, field)
-                            dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
-        else: 
-            if self._normalized_slice is not None:
-                sx, sy = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        for field in self.components:
-                            dset = f.create_dataset(
-                                field, 
-                                data=np.zeros(shape),
-                                dtype='f8',
-                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                            )
-                comm.Barrier()
-            
-                with h5py.File(filename, 'a', locking=False) as f:
-                    for field in self.components:
-                        dset = f[field]
-                        for p in sim.patches:
-                            px = p.ipatch_x * sim.nx_per_patch
-                            py = p.ipatch_y * sim.ny_per_patch
-                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            if x_info is None or y_info is None:
-                                continue
-                            local_x, out_x, num_x = x_info
-                            local_y, out_y, num_y = y_info
-                            data = getattr(p.fields, field)[local_x, local_y]
-                            dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
-                comm.Barrier()
-            else:
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        for field in self.components:
-                            dset = f.create_dataset(
-                                field, 
-                                data=np.zeros((sim.nx, sim.ny)),
-                                dtype='f8',
-                                chunks=chunk_size
-                            )
-                comm.Barrier()
-        
-                with h5py.File(filename, 'a', locking=False) as f:
-                    for field in self.components:
-                        dset = f[field]
-                        for p in sim.patches:
-                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                            data = getattr(p.fields, field)
-                            dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
-
-                comm.Barrier()    
-        # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
                 f.attrs['nx'] = sim.nx
@@ -356,122 +370,14 @@ class SaveFieldsToHDF5(Callback):
                     f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
                 
     def _write_3d(self, sim: Simulation3D, filename: Path):
-        """Write 3D field data to HDF5 file in parallel.
-
-        Args:
-            sim (Simulation3D): 3D simulation object containing field data
-            filename (str): Output HDF5 filename
-
-        Note:
-            - Creates HDF5 file with datasets for each field component
-            - Uses MPI parallel I/O to write patch data
-            - Includes simulation metadata as file attributes
-        """
-        # Get MPI communicator
+        writer = _HDF5SliceWriter(mpi=self.mpi, barrier_after_create=True)
+        writer.write(
+            filename, sim, self.components,
+            lambda ip, p, comp: getattr(p.fields, comp),
+            self._normalized_slice,
+        )
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-        
-        chunk_size = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
-        # Create filename with timestep
-        if self.mpi:
-            if self._normalized_slice is not None:
-                sx, sy, sz = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    for field in self.components:
-                        dset = f.create_dataset(
-                            field, 
-                            data=np.zeros(shape),
-                            dtype='f8',
-                            # chunks=chunk_size
-                        )
-                        comm.Barrier()
-                        for p in sim.patches:
-                            px = p.ipatch_x * sim.nx_per_patch
-                            py = p.ipatch_y * sim.ny_per_patch
-                            pz = p.ipatch_z * sim.nz_per_patch
-                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
-                            if x_info is None or y_info is None or z_info is None:
-                                continue
-                            local_x, out_x, num_x = x_info
-                            local_y, out_y, num_y = y_info
-                            local_z, out_z, num_z = z_info
-                            data = getattr(p.fields, field)[local_x, local_y, local_z]
-                            dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
-            else:
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    for field in self.components:
-                        dset = f.create_dataset(
-                            field, 
-                            data=np.zeros((sim.nx, sim.ny, sim.nz)),
-                            dtype='f8',
-                            # chunks=chunk_size
-                        )
-                        comm.Barrier()
-                        for p in sim.patches:
-                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                            data = getattr(p.fields, field)
-                            dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        else:
-            if self._normalized_slice is not None:
-                sx, sy, sz = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        for field in self.components:
-                            dset = f.create_dataset(
-                                field, 
-                                data=np.zeros(shape),
-                                dtype='f8',
-                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                            )
-                comm.Barrier()
-            
-                # Create chunked dataset with parallel access
-                with h5py.File(filename, 'a', locking=False) as f:
-                    for field in self.components:
-                        dset = f[field]
-                        for p in sim.patches:
-                            px = p.ipatch_x * sim.nx_per_patch
-                            py = p.ipatch_y * sim.ny_per_patch
-                            pz = p.ipatch_z * sim.nz_per_patch
-                            x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                            y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                            z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
-                            if x_info is None or y_info is None or z_info is None:
-                                continue
-                            local_x, out_x, num_x = x_info
-                            local_y, out_y, num_y = y_info
-                            local_z, out_z, num_z = z_info
-                            data = getattr(p.fields, field)[local_x, local_y, local_z]
-                            dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
-                comm.Barrier()
-            else:
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        for field in self.components:
-                            dset = f.create_dataset(
-                                field, 
-                                data=np.zeros((sim.nx, sim.ny, sim.nz)),
-                                dtype='f8',
-                                chunks=chunk_size
-                            )
-                comm.Barrier()
-            
-                # Create chunked dataset with parallel access
-                with h5py.File(filename, 'a', locking=False) as f:
-                    for field in self.components:
-                        dset = f[field]
-                        for p in sim.patches:
-                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                            data = getattr(p.fields, field)
-                            dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-                comm.Barrier()    
-        # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
                 f.attrs['nx'] = sim.nx
@@ -592,98 +498,14 @@ class SaveSpeciesDensityToHDF5(Callback):
         return density
 
     def _write_2d(self, sim: Simulation, density_per_patch: List[np.ndarray], filename: Path):
-        """Write 2D density data to HDF5 file in parallel.
-
-        Args:
-            sim (Simulation): 2D simulation object
-            density_per_patch (List[np.ndarray]): List of density arrays (one per patch)
-
-        Note:
-            - Creates HDF5 file with density dataset
-            - Uses MPI parallel I/O to write patch data
-            - Includes simulation metadata as file attributes
-        """
+        writer = _HDF5SliceWriter(mpi=self.mpi)
+        writer.write(
+            filename, sim, ['density'],
+            lambda ip, p, comp: density_per_patch[ip],
+            self._normalized_slice,
+        )
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-
-        chunk_size = (sim.nx_per_patch, sim.ny_per_patch)
-        if self.mpi:
-            if self._normalized_slice is not None:
-                sx, sy = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    dset = f.create_dataset(
-                        'density',
-                        data=np.zeros(shape, dtype='f8'),
-                        chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                    )
-                    for ip, p in enumerate(sim.patches):
-                        px = p.ipatch_x * sim.nx_per_patch
-                        py = p.ipatch_y * sim.ny_per_patch
-                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                        if x_info is None or y_info is None:
-                            continue
-                        local_x, out_x, num_x = x_info
-                        local_y, out_y, num_y = y_info
-                        data = density_per_patch[ip][local_x, local_y]
-                        dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
-            else:
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    dset = f.create_dataset(
-                        'density',
-                        data=np.zeros((sim.nx, sim.ny), dtype='f8'),
-                        chunks=chunk_size
-                    )
-                    for ip, p in enumerate(sim.patches):
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                        dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
-        else:
-            if self._normalized_slice is not None:
-                sx, sy = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                            dset = f.create_dataset(
-                                'density',
-                                data=np.zeros(shape, dtype='f8'),
-                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                            )
-                comm.Barrier()
-
-                with h5py.File(filename, 'a', locking=False) as f:
-                    dset = f['density']
-                    for ip, p in enumerate(sim.patches):
-                        px = p.ipatch_x * sim.nx_per_patch
-                        py = p.ipatch_y * sim.ny_per_patch
-                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                        if x_info is None or y_info is None:
-                            continue
-                        local_x, out_x, num_x = x_info
-                        local_y, out_y, num_y = y_info
-                        data = density_per_patch[ip][local_x, local_y]
-                        dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
-                comm.Barrier()
-            else:
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        dset = f.create_dataset(
-                            'density',
-                            data=np.zeros((sim.nx, sim.ny), dtype='f8'),
-                            chunks=chunk_size
-                        )
-                comm.Barrier()
-
-                with h5py.File(filename, 'a', locking=False) as f:
-                    dset = f['density']
-                    for ip, p in enumerate(sim.patches):
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                        dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
-                comm.Barrier()
-
         if rank == 0:
             with h5py.File(filename, 'a') as f:
                 f.attrs['time'] = sim.time
@@ -699,104 +521,14 @@ class SaveSpeciesDensityToHDF5(Callback):
                     f.attrs['slice'] = _serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
 
     def _write_3d(self, sim: Simulation3D, density_per_patch: List[np.ndarray], filename: Path):
-        """Write 3D density data to HDF5 file in parallel.
-
-        Args:
-            sim (Simulation3D): 3D simulation object
-            density_per_patch (List[np.ndarray]): List of density arrays (one per patch)
-
-        Note:
-            - Creates HDF5 file with density dataset
-            - Uses MPI parallel I/O to write patch data
-            - Includes simulation metadata as file attributes
-        """
+        writer = _HDF5SliceWriter(mpi=self.mpi)
+        writer.write(
+            filename, sim, ['density'],
+            lambda ip, p, comp: density_per_patch[ip],
+            self._normalized_slice,
+        )
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-
-        chunk_size = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
-        if self.mpi:
-            if self._normalized_slice is not None:
-                sx, sy, sz = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    dset = f.create_dataset(
-                        'density',
-                        data=np.zeros(shape, dtype='f8'),
-                        chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                    )
-                    for ip, p in enumerate(sim.patches):
-                        px = p.ipatch_x * sim.nx_per_patch
-                        py = p.ipatch_y * sim.ny_per_patch
-                        pz = p.ipatch_z * sim.nz_per_patch
-                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                        z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
-                        if x_info is None or y_info is None or z_info is None:
-                            continue
-                        local_x, out_x, num_x = x_info
-                        local_y, out_y, num_y = y_info
-                        local_z, out_z, num_z = z_info
-                        data = density_per_patch[ip][local_x, local_y, local_z]
-                        dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
-            else:
-                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                    dset = f.create_dataset(
-                        'density',
-                        data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
-                        chunks=chunk_size
-                    )
-                    for ip, p in enumerate(sim.patches):
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        else:
-            if self._normalized_slice is not None:
-                sx, sy, sz = self._normalized_slice
-                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        dset = f.create_dataset(
-                            'density',
-                            data=np.zeros(shape, dtype='f8'),
-                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                        )
-                comm.Barrier()
-
-                with h5py.File(filename, 'a', locking=False) as f:
-                    dset = f['density']
-                    for ip, p in enumerate(sim.patches):
-                        px = p.ipatch_x * sim.nx_per_patch
-                        py = p.ipatch_y * sim.ny_per_patch
-                        pz = p.ipatch_z * sim.nz_per_patch
-                        x_info = _compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
-                        y_info = _compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
-                        z_info = _compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
-                        if x_info is None or y_info is None or z_info is None:
-                            continue
-                        local_x, out_x, num_x = x_info
-                        local_y, out_y, num_y = y_info
-                        local_z, out_z, num_z = z_info
-                        data = density_per_patch[ip][local_x, local_y, local_z]
-                        dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
-                comm.Barrier()
-            else:
-                if rank == 0:
-                    with h5py.File(filename, 'w') as f:
-                        dset = f.create_dataset(
-                            'density',
-                            data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
-                            chunks=chunk_size
-                        )
-                comm.Barrier()
-
-                with h5py.File(filename, 'a', locking=False) as f:
-                    dset = f['density']
-                    for ip, p in enumerate(sim.patches):
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-                comm.Barrier()
-
         if rank == 0:
             with h5py.File(filename, 'a') as f:
                 f.attrs['time'] = sim.time

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -1,3 +1,4 @@
+import math
 import os
 from pathlib import Path
 from typing import Callable, List, Optional, Set, Union
@@ -34,13 +35,18 @@ class SaveFieldsToHDF5(Callback):
         components (Optional[List[str]], optional): List of field components to save. 
             Available: ['ex','ey','ez','bx','by','bz','jx','jy','jz','rho']. 
             If None, saves all components.
+        slice (tuple[int | slice, ...] | None, optional): Subset of the domain to save, specified via
+            ``np.s_`` indexing (e.g., ``slice=np.s_[:, :, 100]``, ``slice=np.s_[::2, ::2, ::5]``,
+            ``slice=np.s_[500:, :, :]``). Accepts any ``np.s_``-style tuple of ints and/or slices.
+            If None, saves the full domain. Defaults to None.
     """
     DEFAULT_STAGE = "end"
     def __init__(self, 
                  prefix: Union[str, Path]='', 
                  interval: Union[int, float, Callable] = 100,
                  components: Optional[List[str]] = None,
-                 mpi: bool = False) -> None:
+                 mpi: bool = False,
+                 slice: tuple[int | slice, ...] | None = None) -> None:
         self.stage = self.DEFAULT_STAGE
         self.prefix = Path(prefix)
         self.interval = interval
@@ -61,14 +67,173 @@ class SaveFieldsToHDF5(Callback):
             
         # Create directory if it doesn't exist
         os.makedirs(os.path.dirname(os.path.abspath(prefix)), exist_ok=True)
+        self.slice = slice
+        self._normalized_slice = None
         
     def _call(self, sim: Union[Simulation, Simulation3D]):
+        # Normalize np.s_-style slice input to explicit slice objects
+        if self.slice is not None:
+            if sim.dimension == 2:
+                self._normalized_slice = self._normalize_slice(2, self.slice, (sim.nx, sim.ny))
+            elif sim.dimension == 3:
+                self._normalized_slice = self._normalize_slice(3, self.slice, (sim.nx, sim.ny, sim.nz))
+        else:
+            self._normalized_slice = None
         filename = self.prefix / f"{sim.itime:06d}.h5"
         if sim.dimension == 2:
             self._write_2d(sim, filename)
         elif sim.dimension == 3:
             self._write_3d(sim, filename)
         
+    @staticmethod
+    def _normalize_slice(sim_dim: int, user_slice: tuple[int | slice, ...], dims: tuple) -> tuple[slice, ...] | None:
+        """Normalize a user-provided slice specification to full slice objects.
+
+        Converts ints to ``slice(i, i+1, 1)`` and ``slice(None)`` to ``slice(0, dim, 1)``.
+
+        Args:
+            sim_dim (int): Number of dimensions (2 or 3).
+            user_slice (tuple[int | slice, ...]): User-provided ``np.s_``-style slice tuple,
+                e.g. ``np.s_[:, :, 100]`` or ``np.s_[::2, ::2, ::5]``.
+            dims (tuple): Size of each dimension, e.g. ``(nx, ny)``.
+
+        Returns:
+            Optional[tuple]: Normalized tuple of ``slice`` objects, or ``None`` if
+                ``user_slice`` is ``None``.
+
+        Raises:
+            ValueError: If the slice specification contains invalid types, out-of-bounds
+                indices, or negative steps.
+        """
+        if user_slice is None:
+            return None
+        
+        # Wrap single slice or int in tuple
+        if isinstance(user_slice, (slice, int)):
+            user_slice = (user_slice,)
+        
+        # Reject Ellipsis
+        if any(isinstance(s, type(Ellipsis)) for s in user_slice):
+            raise ValueError("Ellipsis (...) is not supported in slice specification")
+        
+        # Reject None/np.newaxis
+        if any(s is None for s in user_slice):
+            raise ValueError("None/np.newaxis is not supported in slice specification")
+        
+        # Validate length
+        if len(user_slice) != sim_dim:
+            raise ValueError(
+                f"Slice tuple length {len(user_slice)} does not match "
+                f"simulation dimension {sim_dim}"
+            )
+        
+        result = []
+        for i, s in enumerate(user_slice):
+            dim = dims[i]
+            if isinstance(s, int):
+                # Normalize negative index
+                if s < 0:
+                    s = dim + s
+                if s < 0 or s >= dim:
+                    raise ValueError(
+                        f"Index {s} out of bounds for dimension {i} with size {dim}"
+                    )
+                result.append(slice(s, s + 1, 1))
+            elif isinstance(s, slice):
+                start, stop, step = s.start, s.stop, s.step
+                # Fill defaults
+                if start is None:
+                    start = 0
+                if stop is None:
+                    stop = dim
+                if step is None:
+                    step = 1
+                # Validate step
+                if step <= 0:
+                    raise ValueError(f"Step must be positive, got {step}")
+                # Resolve negatives
+                if start < 0:
+                    start = dim + start
+                if stop < 0:
+                    stop = dim + stop
+                # Clamp to valid range
+                start = max(0, min(start, dim))
+                stop = max(0, min(stop, dim))
+                # Validate at least 1 element
+                if start >= stop:
+                    raise ValueError(
+                        f"Slice {s} has no elements for dimension {i} with size {dim}"
+                    )
+                result.append(slice(start, stop, step))
+            else:
+                raise ValueError(
+                    f"Invalid slice element type: {type(s).__name__}. "
+                    f"Expected int or slice."
+                )
+        
+        return tuple(result)
+    
+    @staticmethod
+    def _compute_patch_slice(axis_dim: int, global_slice: slice,
+                             patch_offset: int, patch_size: int) -> Optional[tuple]:
+        """Compute the local slice for a single patch along one axis.
+
+        Determines which elements of a patch are selected by a global slice.
+
+        Args:
+            axis_dim (int): Total size of this axis (e.g., ``sim.nx``).
+            global_slice (slice): Normalized slice for this axis (start, stop, step).
+            patch_offset (int): Global offset of this patch (``ipatch * n_per_patch``).
+            patch_size (int): Size of this patch (``n_per_patch``).
+
+        Returns:
+            Optional[tuple]: ``(local_slice, output_start, num_elements)`` or ``None``
+                if the patch does not intersect the slice.
+        """
+        start, stop, step = global_slice.start, global_slice.stop, global_slice.step
+        offset, size = patch_offset, patch_size
+        
+        first = start + math.ceil(max(0, offset - start) / step) * step
+        last_global_in_patch = min(stop, offset + size) - 1
+        last_selected = start + math.floor((last_global_in_patch - start) / step) * step
+        
+        if last_selected < first:
+            return None
+        
+        local_first = first - offset
+        output_start = (first - start) // step
+        num = (last_selected - first) // step + 1
+        local_slice = slice(local_first, local_first + num * step, step)
+        
+        return (local_slice, output_start, num)
+    
+    @staticmethod
+    def _serialize_slice(normalized_slice: tuple, dims: tuple) -> str:
+        """Convert a normalized slice tuple to a human-readable string.
+
+        Args:
+            normalized_slice (tuple): Normalized tuple of ``slice`` objects.
+            dims (tuple): Full size of each axis in the simulation domain.
+
+        Returns:
+            str: Human-readable string such as ``"[:, :, 100]"``.
+        """
+        parts = []
+        for s, dim in zip(normalized_slice, dims):
+            if s.start == 0 and s.stop == dim and s.step == 1:
+                parts.append(":")
+            elif s.step == 1 and s.stop == s.start + 1:
+                # Single element like slice(i, i+1, 1) -> "i"
+                parts.append(str(s.start))
+            else:
+                start = "" if s.start == 0 else str(s.start)
+                stop = "" if s.stop == dim else str(s.stop)
+                if s.step == 1:
+                    parts.append(f"{start}:{stop}")
+                else:
+                    parts.append(f"{start}:{stop}:{s.step}")
+        return "[" + ", ".join(parts) + "]"
+    
     def _write_2d(self, sim: Simulation, filename: Path):
         """Write 2D field data to HDF5 file in parallel.
 
@@ -88,22 +253,30 @@ class SaveFieldsToHDF5(Callback):
         chunk_size = (sim.nx_per_patch, sim.ny_per_patch)
         # Create filename with timestep
         if self.mpi:
-            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                for field in self.components:
-                    dset = f.create_dataset(
-                        field, 
-                        data=np.zeros((sim.nx, sim.ny)),
-                        dtype='f8',
-                        chunks=chunk_size
-                    )
-                    for p in sim.patches:
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                        data = getattr(p.fields, field)
-                        dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
-        else: 
-            if rank == 0:
-                with h5py.File(filename, 'w') as f:
+            if self._normalized_slice is not None:
+                sx, sy = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
+                    for field in self.components:
+                        dset = f.create_dataset(
+                            field, 
+                            data=np.zeros(shape),
+                            dtype='f8',
+                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                        )
+                        for p in sim.patches:
+                            px = p.ipatch_x * sim.nx_per_patch
+                            py = p.ipatch_y * sim.ny_per_patch
+                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            if x_info is None or y_info is None:
+                                continue
+                            local_x, out_x, num_x = x_info
+                            local_y, out_y, num_y = y_info
+                            data = getattr(p.fields, field)[local_x, local_y]
+                            dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
+            else:
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                     for field in self.components:
                         dset = f.create_dataset(
                             field, 
@@ -111,18 +284,63 @@ class SaveFieldsToHDF5(Callback):
                             dtype='f8',
                             chunks=chunk_size
                         )
-            comm.Barrier()
+                        for p in sim.patches:
+                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                            data = getattr(p.fields, field)
+                            dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
+        else: 
+            if self._normalized_slice is not None:
+                sx, sy = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        for field in self.components:
+                            dset = f.create_dataset(
+                                field, 
+                                data=np.zeros(shape),
+                                dtype='f8',
+                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                            )
+                comm.Barrier()
+            
+                with h5py.File(filename, 'a', locking=False) as f:
+                    for field in self.components:
+                        dset = f[field]
+                        for p in sim.patches:
+                            px = p.ipatch_x * sim.nx_per_patch
+                            py = p.ipatch_y * sim.ny_per_patch
+                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            if x_info is None or y_info is None:
+                                continue
+                            local_x, out_x, num_x = x_info
+                            local_y, out_y, num_y = y_info
+                            data = getattr(p.fields, field)[local_x, local_y]
+                            dset[out_x:out_x+num_x, out_y:out_y+num_y] = data
+                comm.Barrier()
+            else:
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        for field in self.components:
+                            dset = f.create_dataset(
+                                field, 
+                                data=np.zeros((sim.nx, sim.ny)),
+                                dtype='f8',
+                                chunks=chunk_size
+                            )
+                comm.Barrier()
         
-            with h5py.File(filename, 'a', locking=False) as f:
-                for field in self.components:
-                    dset = f[field]
-                    for p in sim.patches:
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                        data = getattr(p.fields, field)
-                        dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
+                with h5py.File(filename, 'a', locking=False) as f:
+                    for field in self.components:
+                        dset = f[field]
+                        for p in sim.patches:
+                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                            data = getattr(p.fields, field)
+                            dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
 
-            comm.Barrier()    
+                comm.Barrier()    
         # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -134,6 +352,8 @@ class SaveFieldsToHDF5(Callback):
                 f.attrs['Ly'] = sim.Ly
                 f.attrs['time'] = sim.time
                 f.attrs['itime'] = sim.itime
+                if self._normalized_slice is not None:
+                    f.attrs['slice'] = self._serialize_slice(self._normalized_slice, (sim.nx, sim.ny))
                 
     def _write_3d(self, sim: Simulation3D, filename: Path):
         """Write 3D field data to HDF5 file in parallel.
@@ -154,42 +374,103 @@ class SaveFieldsToHDF5(Callback):
         chunk_size = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
         # Create filename with timestep
         if self.mpi:
-            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
-                for field in self.components:
-                    dset = f.create_dataset(
-                        field, 
-                        data=np.zeros((sim.nx, sim.ny, sim.nz)),
-                        dtype='f8',
-                        # chunks=chunk_size
-                    )
-                    comm.Barrier()
-                    for p in sim.patches:
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                        data = getattr(p.fields, field)
-                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        else:
-            if rank == 0:
-                with h5py.File(filename, 'w') as f:
+            if self._normalized_slice is not None:
+                sx, sy, sz = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
+                    for field in self.components:
+                        dset = f.create_dataset(
+                            field, 
+                            data=np.zeros(shape),
+                            dtype='f8',
+                            # chunks=chunk_size
+                        )
+                        comm.Barrier()
+                        for p in sim.patches:
+                            px = p.ipatch_x * sim.nx_per_patch
+                            py = p.ipatch_y * sim.ny_per_patch
+                            pz = p.ipatch_z * sim.nz_per_patch
+                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            z_info = self._compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                            if x_info is None or y_info is None or z_info is None:
+                                continue
+                            local_x, out_x, num_x = x_info
+                            local_y, out_y, num_y = y_info
+                            local_z, out_z, num_z = z_info
+                            data = getattr(p.fields, field)[local_x, local_y, local_z]
+                            dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+            else:
+                with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                     for field in self.components:
                         dset = f.create_dataset(
                             field, 
                             data=np.zeros((sim.nx, sim.ny, sim.nz)),
                             dtype='f8',
-                            chunks=chunk_size
+                            # chunks=chunk_size
                         )
-            comm.Barrier()
+                        comm.Barrier()
+                        for p in sim.patches:
+                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                            data = getattr(p.fields, field)
+                            dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        else:
+            if self._normalized_slice is not None:
+                sx, sy, sz = self._normalized_slice
+                shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step)))
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        for field in self.components:
+                            dset = f.create_dataset(
+                                field, 
+                                data=np.zeros(shape),
+                                dtype='f8',
+                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                            )
+                comm.Barrier()
             
-            # Create chunked dataset with parallel access
-            with h5py.File(filename, 'a', locking=False) as f:
-                for field in self.components:
-                    dset = f[field]
-                    for p in sim.patches:
-                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                        data = getattr(p.fields, field)
-                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-            comm.Barrier()    
+                # Create chunked dataset with parallel access
+                with h5py.File(filename, 'a', locking=False) as f:
+                    for field in self.components:
+                        dset = f[field]
+                        for p in sim.patches:
+                            px = p.ipatch_x * sim.nx_per_patch
+                            py = p.ipatch_y * sim.ny_per_patch
+                            pz = p.ipatch_z * sim.nz_per_patch
+                            x_info = self._compute_patch_slice(sim.nx, sx, px, sim.nx_per_patch)
+                            y_info = self._compute_patch_slice(sim.ny, sy, py, sim.ny_per_patch)
+                            z_info = self._compute_patch_slice(sim.nz, sz, pz, sim.nz_per_patch)
+                            if x_info is None or y_info is None or z_info is None:
+                                continue
+                            local_x, out_x, num_x = x_info
+                            local_y, out_y, num_y = y_info
+                            local_z, out_z, num_z = z_info
+                            data = getattr(p.fields, field)[local_x, local_y, local_z]
+                            dset[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+                comm.Barrier()
+            else:
+                if rank == 0:
+                    with h5py.File(filename, 'w') as f:
+                        for field in self.components:
+                            dset = f.create_dataset(
+                                field, 
+                                data=np.zeros((sim.nx, sim.ny, sim.nz)),
+                                dtype='f8',
+                                chunks=chunk_size
+                            )
+                comm.Barrier()
+            
+                # Create chunked dataset with parallel access
+                with h5py.File(filename, 'a', locking=False) as f:
+                    for field in self.components:
+                        dset = f[field]
+                        for p in sim.patches:
+                            start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                            end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                            data = getattr(p.fields, field)
+                            dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+                comm.Barrier()    
         # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -204,6 +485,8 @@ class SaveFieldsToHDF5(Callback):
                 f.attrs['Lz'] = sim.Lz
                 f.attrs['time'] = sim.time
                 f.attrs['itime'] = sim.itime
+                if self._normalized_slice is not None:
+                    f.attrs['slice'] = self._serialize_slice(self._normalized_slice, (sim.nx, sim.ny, sim.nz))
         comm.Barrier()
 
 

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -39,10 +39,12 @@ class SaveFieldsToHDF5(Callback):
     def __init__(self, 
                  prefix: Union[str, Path]='', 
                  interval: Union[int, float, Callable] = 100,
-                 components: Optional[List[str]] = None) -> None:
+                 components: Optional[List[str]] = None,
+                 mpi: bool = False) -> None:
         self.stage = self.DEFAULT_STAGE
         self.prefix = Path(prefix)
         self.interval = interval
+        self.mpi = mpi
 
         self.prefix.mkdir(parents=True, exist_ok=True)
         
@@ -85,9 +87,8 @@ class SaveFieldsToHDF5(Callback):
         
         chunk_size = (sim.nx_per_patch, sim.ny_per_patch)
         # Create filename with timestep
-
-        if rank == 0:
-            with h5py.File(filename, 'w') as f:
+        if self.mpi:
+            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                 for field in self.components:
                     dset = f.create_dataset(
                         field, 
@@ -95,19 +96,33 @@ class SaveFieldsToHDF5(Callback):
                         dtype='f8',
                         chunks=chunk_size
                     )
-        comm.Barrier()
+                    for p in sim.patches:
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                        data = getattr(p.fields, field)
+                        dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
+        else: 
+            if rank == 0:
+                with h5py.File(filename, 'w') as f:
+                    for field in self.components:
+                        dset = f.create_dataset(
+                            field, 
+                            data=np.zeros((sim.nx, sim.ny)),
+                            dtype='f8',
+                            chunks=chunk_size
+                        )
+            comm.Barrier()
         
-        # Create chunked dataset with parallel access
-        with h5py.File(filename, 'a', locking=False) as f:
-            for field in self.components:
-                dset = f[field]
-                for p in sim.patches:
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                    data = getattr(p.fields, field)
-                    dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
+            with h5py.File(filename, 'a', locking=False) as f:
+                for field in self.components:
+                    dset = f[field]
+                    for p in sim.patches:
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                        data = getattr(p.fields, field)
+                        dset[start[0]:end[0], start[1]:end[1]] = data[:sim.nx_per_patch, :sim.ny_per_patch]
 
-        comm.Barrier()    
+            comm.Barrier()    
         # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -138,27 +153,43 @@ class SaveFieldsToHDF5(Callback):
         
         chunk_size = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
         # Create filename with timestep
-        if rank == 0:
-            with h5py.File(filename, 'w') as f:
+        if self.mpi:
+            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                 for field in self.components:
                     dset = f.create_dataset(
                         field, 
                         data=np.zeros((sim.nx, sim.ny, sim.nz)),
                         dtype='f8',
-                        chunks=chunk_size
+                        # chunks=chunk_size
                     )
-        comm.Barrier()
-        
-        # Create chunked dataset with parallel access
-        with h5py.File(filename, 'a', locking=False) as f:
-            for field in self.components:
-                dset = f[field]
-                for p in sim.patches:
-                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                    data = getattr(p.fields, field)
-                    dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        comm.Barrier()    
+                    comm.Barrier()
+                    for p in sim.patches:
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                        data = getattr(p.fields, field)
+                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        else:
+            if rank == 0:
+                with h5py.File(filename, 'w') as f:
+                    for field in self.components:
+                        dset = f.create_dataset(
+                            field, 
+                            data=np.zeros((sim.nx, sim.ny, sim.nz)),
+                            dtype='f8',
+                            chunks=chunk_size
+                        )
+            comm.Barrier()
+            
+            # Create chunked dataset with parallel access
+            with h5py.File(filename, 'a', locking=False) as f:
+                for field in self.components:
+                    dset = f[field]
+                    for p in sim.patches:
+                        start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                        end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                        data = getattr(p.fields, field)
+                        dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = data[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+            comm.Barrier()    
         # Only rank 0 writes metadata
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -196,10 +227,11 @@ class SaveSpeciesDensityToHDF5(Callback):
             function(sim) -> bool that determines when to save. Defaults to 100.
     """
     stage = "current_deposition"
-    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100):
+    def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100, mpi: bool = False):
         self.species = species
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)
+        self.mpi = mpi
 
         self.interval = interval
         self.prev_rho = None
@@ -276,23 +308,35 @@ class SaveSpeciesDensityToHDF5(Callback):
         """
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-        
-        if rank == 0:
-            with h5py.File(filename, 'w') as f:
+
+        if self.mpi:
+            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                 dset = f.create_dataset(
                     'density', 
                     data=np.zeros((sim.nx, sim.ny), dtype='f8'),
                     chunks=(sim.nx_per_patch, sim.ny_per_patch)
                 )
-        comm.Barrier()
+                for ip, p in enumerate(sim.patches):
+                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                    dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
+        else:
+            if rank == 0:
+                with h5py.File(filename, 'w') as f:
+                    dset = f.create_dataset(
+                        'density', 
+                        data=np.zeros((sim.nx, sim.ny), dtype='f8'),
+                        chunks=(sim.nx_per_patch, sim.ny_per_patch)
+                    )
+            comm.Barrier()
 
-        with h5py.File(filename, 'a', locking=False) as f:
-            dset = f['density']
-            for ip, p in enumerate(sim.patches):
-                start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
-                end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
-                dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
-        comm.Barrier()
+            with h5py.File(filename, 'a', locking=False) as f:
+                dset = f['density']
+                for ip, p in enumerate(sim.patches):
+                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch
+                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch
+                    dset[start[0]:end[0], start[1]:end[1]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch]
+            comm.Barrier()
 
         if rank == 0:
             with h5py.File(filename, 'a') as f:
@@ -320,24 +364,38 @@ class SaveSpeciesDensityToHDF5(Callback):
         """
         comm = sim.mpi.comm
         rank = comm.Get_rank()
-        
-        if rank == 0:
-            with h5py.File(filename, 'w') as f:
+
+        if self.mpi:
+            with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
                 dset = f.create_dataset(
                     'density', 
                     data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
                     dtype='f8',
                     chunks=(sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
                 )
-        comm.Barrier()
 
-        with h5py.File(filename, 'a', locking=False) as f:
-            dset = f['density']
-            for ip, p in enumerate(sim.patches):
-                start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
-                end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
-                dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
-        comm.Barrier()
+                for ip, p in enumerate(sim.patches):
+                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                    dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        else:
+            if rank == 0:
+                with h5py.File(filename, 'w') as f:
+                    dset = f.create_dataset(
+                        'density', 
+                        data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
+                        dtype='f8',
+                        chunks=(sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
+                    )
+            comm.Barrier()
+
+            with h5py.File(filename, 'a', locking=False) as f:
+                dset = f['density']
+                for ip, p in enumerate(sim.patches):
+                    start = p.ipatch_x * sim.nx_per_patch, p.ipatch_y * sim.ny_per_patch, p.ipatch_z * sim.nz_per_patch
+                    end   = start[0] + sim.nx_per_patch, start[1] + sim.ny_per_patch, start[2] + sim.nz_per_patch
+                    dset[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = density_per_patch[ip][:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+            comm.Barrier()
 
         if rank == 0:
             with h5py.File(filename, 'a') as f:

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -1,5 +1,4 @@
 import math
-import os
 from pathlib import Path
 from typing import Callable, List, Optional, Set, Union
 
@@ -317,7 +316,7 @@ class SaveFieldsToHDF5(Callback):
         self.mpi = mpi
 
         self.prefix.mkdir(parents=True, exist_ok=True)
-        
+
         # Available field components
         self.all_components = {'ex','ey','ez','bx','by','bz','jx','jy','jz','rho'}
         if components is None:
@@ -328,9 +327,7 @@ class SaveFieldsToHDF5(Callback):
             if invalid:
                 raise ValueError(f"Invalid field components: {invalid}")
             self.components = list(components)
-            
-        # Create directory if it doesn't exist
-        os.makedirs(os.path.dirname(os.path.abspath(prefix)), exist_ok=True)
+
         self.slice = slice
         self._normalized_slice = None
         
@@ -422,8 +419,9 @@ class SaveSpeciesDensityToHDF5(Callback):
             ``slice=np.s_[500:, :, :]``). Accepts any ``np.s_``-style tuple of ints and/or slices.
             If None, saves the full domain. Defaults to None.
     """
-    stage = "current_deposition"
+    DEFAULT_STAGE = "current_deposition"
     def __init__(self, species: Species, prefix: Union[str, Path]='', interval: Union[int, float, Callable] = 100, mpi: bool = False, slice: tuple[int | slice, ...] | None = None):
+        self.stage = self.DEFAULT_STAGE
         self.species = species
         self.prefix = Path(prefix)
         self.prefix.mkdir(parents=True, exist_ok=True)
@@ -434,7 +432,6 @@ class SaveSpeciesDensityToHDF5(Callback):
         self.species = species
         self.slice = slice
         self._normalized_slice = None
-        os.makedirs(os.path.dirname(os.path.abspath(prefix)), exist_ok=True)
 
     @property
     def ispec_target(self) -> int:
@@ -650,14 +647,11 @@ class SaveParticlesToHDF5(Callback):
         self.interval = interval
         self.attrs = attrs
         self.species = species
-        
+
         if self.attrs is None:
             logger.warning("No attributes specified, saving all attributes.")
         elif 'id' in self.attrs:
             self.attrs.remove('id')
-        
-        # Create directory if it doesn't exist
-        os.makedirs(os.path.dirname(os.path.abspath(prefix)), exist_ok=True)
     
     def _call(self, sim: Union[Simulation, Simulation3D]):
         if self.attrs is None:

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -174,12 +174,13 @@ class _HDF5SliceWriter:
         components: list[str],
         patch_data_fn: Callable[[int, object, str], np.ndarray],
         normalized_slice: tuple[slice, ...] | None,
+        pre_sliced: bool = False,
     ):
         """Write multi-component data to HDF5, handling 2D/3D, MPI/non-MPI, and optional slicing."""
         if sim.dimension == 2:
-            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 2)
+            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 2, pre_sliced)
         elif sim.dimension == 3:
-            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 3)
+            self._write_nd(filename, sim, components, patch_data_fn, normalized_slice, 3, pre_sliced)
 
     def _write_nd(
         self,
@@ -189,6 +190,7 @@ class _HDF5SliceWriter:
         patch_data_fn: Callable[[int, object, str], np.ndarray],
         normalized_slice: tuple[slice, ...] | None,
         ndim: int,
+        pre_sliced: bool = False,
     ):
         comm = sim.mpi.comm
         rank = comm.Get_rank()
@@ -207,12 +209,12 @@ class _HDF5SliceWriter:
         chunk_size = tuple(min(c, s) for c, s in zip(per_patch, shape))
 
         if self.mpi:
-            self._write_mpi(filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size)
+            self._write_mpi(filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size, pre_sliced)
         else:
-            self._write_non_mpi(filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size)
+            self._write_non_mpi(filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size, pre_sliced)
 
     def _write_mpi(
-        self, filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size,
+        self, filename, sim, comm, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size, pre_sliced: bool = False,
     ):
         with h5py.File(filename, 'w', driver='mpio', comm=comm) as f:
             for comp in components:
@@ -231,12 +233,13 @@ class _HDF5SliceWriter:
                     nums = [si[2] for si in slices_info]
 
                     data = patch_data_fn(ip, p, comp)
-                    data = data[tuple(local_slices)]
+                    if not pre_sliced:
+                        data = data[tuple(local_slices)]
                     out_idx = tuple(slice(o, o + n) for o, n in zip(out_starts, nums))
                     dset[out_idx] = data
 
     def _write_non_mpi(
-        self, filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size,
+        self, filename, sim, comm, rank, components, patch_data_fn, normalized_slice, ndim, dims, per_patch, shape, chunk_size, pre_sliced: bool = False,
     ):
         if rank == 0:
             with h5py.File(filename, 'w') as f:
@@ -260,7 +263,8 @@ class _HDF5SliceWriter:
                     nums = [si[2] for si in slices_info]
 
                     data = patch_data_fn(ip, p, comp)
-                    data = data[tuple(local_slices)]
+                    if not pre_sliced:
+                        data = data[tuple(local_slices)]
                     out_idx = tuple(slice(o, o + n) for o, n in zip(out_starts, nums))
                     dset[out_idx] = data
         comm.Barrier()
@@ -458,7 +462,7 @@ class SaveSpeciesDensityToHDF5(Callback):
         if self.ispec_target == 0:
             if sim.ispec == 0:
                 sim.sync_currents()
-                density = self._compute_density(sim)
+                density = self._compute_density(sim, self._normalized_slice)
                 if sim.dimension == 2:
                     self._write_2d(sim, density, filename)
                 elif sim.dimension == 3:
@@ -466,34 +470,94 @@ class SaveSpeciesDensityToHDF5(Callback):
         else:
             if sim.ispec == self.ispec_target - 1:
                 sim.sync_currents()
-                self.prev_rho = []
-                for p in sim.patches:
-                    self.prev_rho.append(p.fields.rho.copy())
+                self.prev_rho = self._extract_prev_rho(sim, self._normalized_slice)
             elif sim.ispec == self.ispec_target:
                 sim.sync_currents()
-                density = self._compute_density(sim)
+                density = self._compute_density(sim, self._normalized_slice)
                 if sim.dimension == 2:
                     self._write_2d(sim, density, filename)
                 elif sim.dimension == 3:
                     self._write_3d(sim, density, filename)
                 self.prev_rho = None
 
-    def _compute_density(self, sim: Union[Simulation, Simulation3D]) -> List[np.ndarray]:
-        """Compute density from charge density for all patches.
+    def _extract_prev_rho(self, sim: Union[Simulation, Simulation3D], normalized_slice: tuple[slice, ...] | None) -> List[np.ndarray | None]:
+        if normalized_slice is None:
+            if sim.dimension == 2:
+                return [p.fields.rho[:p.fields.nx, :p.fields.ny].copy() for p in sim.patches]
+            else:
+                return [p.fields.rho[:p.fields.nx, :p.fields.ny, :p.fields.nz].copy() for p in sim.patches]
 
-        Args:
-            sim (Union[Simulation, Simulation3D]): The simulation object containing field data
+        ndim = sim.dimension
+        if ndim == 2:
+            dims = (sim.nx, sim.ny)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch)
+        else:
+            dims = (sim.nx, sim.ny, sim.nz)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
 
-        Returns:
-            List[np.ndarray]: List of density arrays (one per patch)
-        """
+        prev_rho = []
+        for ip, p in enumerate(sim.patches):
+            offsets = _HDF5SliceWriter._patch_offsets(p, sim, ndim)
+            slices_info = [
+                _compute_patch_slice(d, s, o, pp)
+                for d, s, o, pp in zip(dims, normalized_slice, offsets, per_patch)
+            ]
+            if any(si is None for si in slices_info):
+                if ndim == 2:
+                    prev_rho.append(np.zeros((0, 0)))
+                else:
+                    prev_rho.append(np.zeros((0, 0, 0)))
+                continue
+
+            local_slices = tuple(si[0] for si in slices_info)
+            prev_rho.append(p.fields.rho[local_slices].copy())
+
+        return prev_rho
+
+    def _compute_density(self, sim: Union[Simulation, Simulation3D], normalized_slice: tuple[slice, ...] | None) -> List[np.ndarray | None]:
+        if normalized_slice is None:
+            density = []
+            for ip, p in enumerate(sim.patches):
+                if sim.dimension == 2:
+                    rho = p.fields.rho[:p.fields.nx, :p.fields.ny]
+                else:
+                    rho = p.fields.rho[:p.fields.nx, :p.fields.ny, :p.fields.nz]
+                if self.ispec_target == 0:
+                    d = rho / self.species.q
+                else:
+                    d = (rho - self.prev_rho[ip]) / self.species.q
+                density.append(d)
+            return density
+
+        ndim = sim.dimension
+        if ndim == 2:
+            dims = (sim.nx, sim.ny)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch)
+        else:
+            dims = (sim.nx, sim.ny, sim.nz)
+            per_patch = (sim.nx_per_patch, sim.ny_per_patch, sim.nz_per_patch)
+
         density = []
         for ip, p in enumerate(sim.patches):
+            offsets = _HDF5SliceWriter._patch_offsets(p, sim, ndim)
+            slices_info = [
+                _compute_patch_slice(d, s, o, pp)
+                for d, s, o, pp in zip(dims, normalized_slice, offsets, per_patch)
+            ]
+            if any(si is None for si in slices_info):
+                if ndim == 2:
+                    density.append(np.zeros((0, 0)))
+                else:
+                    density.append(np.zeros((0, 0, 0)))
+                continue
+
+            local_slices = tuple(si[0] for si in slices_info)
             if self.ispec_target == 0:
-                d = p.fields.rho / self.species.q
+                rho = p.fields.rho[local_slices]
             else:
-                d = (p.fields.rho - self.prev_rho[ip]) / self.species.q
-            density.append(d)
+                rho = p.fields.rho[local_slices] - self.prev_rho[ip]
+            density.append(rho / self.species.q)
+
         return density
 
     def _write_2d(self, sim: Simulation, density_per_patch: List[np.ndarray], filename: Path):
@@ -502,6 +566,7 @@ class SaveSpeciesDensityToHDF5(Callback):
             filename, sim, ['density'],
             lambda ip, p, comp: density_per_patch[ip],
             self._normalized_slice,
+            pre_sliced=True,
         )
         comm = sim.mpi.comm
         rank = comm.Get_rank()
@@ -526,6 +591,7 @@ class SaveSpeciesDensityToHDF5(Callback):
             filename, sim, ['density'],
             lambda ip, p, comp: density_per_patch[ip],
             self._normalized_slice,
+            pre_sliced=True,
         )
         comm = sim.mpi.comm
         rank = comm.Get_rank()

--- a/src/lambdapic/callback/hdf5.py
+++ b/src/lambdapic/callback/hdf5.py
@@ -35,7 +35,7 @@ def _normalize_slice(sim_dim: int, user_slice: tuple[int | slice, ...], dims: tu
         return None
     
     # Wrap single slice or int in tuple
-    if isinstance(user_slice, (slice, int)):
+    if isinstance(user_slice, (slice, int, np.integer)):
         user_slice = (user_slice,)
     
     # Reject Ellipsis
@@ -56,7 +56,7 @@ def _normalize_slice(sim_dim: int, user_slice: tuple[int | slice, ...], dims: tu
     result = []
     for i, s in enumerate(user_slice):
         dim = dims[i]
-        if isinstance(s, int):
+        if isinstance(s, (int, np.integer)):
             # Normalize negative index
             if s < 0:
                 s = dim + s
@@ -615,7 +615,6 @@ class SaveSpeciesDensityToHDF5(Callback):
                     dset = f.create_dataset(
                         'density',
                         data=np.zeros(shape, dtype='f8'),
-                        dtype='f8',
                         chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
                     )
                     for ip, p in enumerate(sim.patches):
@@ -646,12 +645,11 @@ class SaveSpeciesDensityToHDF5(Callback):
                 shape = (len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)))
                 if rank == 0:
                     with h5py.File(filename, 'w') as f:
-                        dset = f.create_dataset(
-                            'density',
-                            data=np.zeros(shape, dtype='f8'),
-                            dtype='f8',
-                            chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
-                        )
+                            dset = f.create_dataset(
+                                'density',
+                                data=np.zeros(shape, dtype='f8'),
+                                chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
+                            )
                 comm.Barrier()
 
                 with h5py.File(filename, 'a', locking=False) as f:
@@ -724,7 +722,6 @@ class SaveSpeciesDensityToHDF5(Callback):
                     dset = f.create_dataset(
                         'density',
                         data=np.zeros(shape, dtype='f8'),
-                        dtype='f8',
                         chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
                     )
                     for ip, p in enumerate(sim.patches):
@@ -746,7 +743,6 @@ class SaveSpeciesDensityToHDF5(Callback):
                     dset = f.create_dataset(
                         'density',
                         data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
-                        dtype='f8',
                         chunks=chunk_size
                     )
                     for ip, p in enumerate(sim.patches):
@@ -762,7 +758,6 @@ class SaveSpeciesDensityToHDF5(Callback):
                         dset = f.create_dataset(
                             'density',
                             data=np.zeros(shape, dtype='f8'),
-                            dtype='f8',
                             chunks=tuple(min(c, s) for c, s in zip(chunk_size, shape))
                         )
                 comm.Barrier()
@@ -790,7 +785,6 @@ class SaveSpeciesDensityToHDF5(Callback):
                         dset = f.create_dataset(
                             'density',
                             data=np.zeros((sim.nx, sim.ny, sim.nz), dtype='f8'),
-                            dtype='f8',
                             chunks=chunk_size
                         )
                 comm.Barrier()

--- a/src/lambdapic/callback/plot.py
+++ b/src/lambdapic/callback/plot.py
@@ -50,7 +50,7 @@ class PlotFields(Callback):
         ...     extract_ne,
         ...     PlotFields(field_configs, prefix='plots', interleval=100)])
     """
-    stage = "maxwell_2"
+    DEFAULT_STAGE = "end"
 
     def __init__(self,
                  field_configs: List[Dict],
@@ -58,6 +58,7 @@ class PlotFields(Callback):
                  interval: Union[int, float, Callable] = 100,
                  figsize: tuple | None = None,
                  dpi: int = 300):
+        self.stage = self.DEFAULT_STAGE
         self.prefix = Path(prefix)
         self.field_configs = field_configs
         self.interval = interval

--- a/src/lambdapic/callback/restart.py
+++ b/src/lambdapic/callback/restart.py
@@ -13,10 +13,10 @@ from .callback import Callback
 class RestartDump(Callback):
     """Callback that persists per-rank restart checkpoints for later replay.
 
-    The callback runs during the Maxwell solver's second stage and captures one
-    shard per MPI rank inside ``out_dir/ckpt_<itime>/``. Each shard stores the
-    full ``Simulation`` state so a subsequent :meth:`RestartDump.load` call can
-    resume execution on the same rank topology.
+    The callback runs at stage ``"end"`` and captures one shard per MPI rank
+    inside ``out_dir/ckpt_<itime>/``. Each shard stores the full ``Simulation``
+    state so a subsequent :meth:`RestartDump.load` call can resume execution on
+    the same rank topology.
 
     Parameters
     ----------
@@ -52,10 +52,11 @@ class RestartDump(Callback):
     time limit of job scheduler like slurm.
     """
 
-    stage = "end"
+    DEFAULT_STAGE = "end"
 
-    def __init__(self, out_dir: Union[str, Path], interval: Union[int, float, Callable] = 1000, keep: Optional[int] = None, 
+    def __init__(self, out_dir: Union[str, Path], interval: Union[int, float, Callable] = 1000, keep: Optional[int] = None,
                  dump_signals: list[int]|bool=False) -> None:
+        self.stage = self.DEFAULT_STAGE
         self.out_dir = Path(out_dir)
         self.interval = interval
         self.keep = keep

--- a/src/lambdapic/callback/restart.py
+++ b/src/lambdapic/callback/restart.py
@@ -52,7 +52,7 @@ class RestartDump(Callback):
     time limit of job scheduler like slurm.
     """
 
-    stage = "maxwell_2"
+    stage = "end"
 
     def __init__(self, out_dir: Union[str, Path], interval: Union[int, float, Callable] = 1000, keep: Optional[int] = None, 
                  dump_signals: list[int]|bool=False) -> None:

--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -7,7 +7,7 @@ from numba import typed
 from numpy.typing import NDArray
 from scipy.constants import c, e, epsilon_0, m_e, mu_0, pi
 
-from lambdapic.callback.hdf5 import SaveSpeciesDensityToHDF5
+from lambdapic.callback.hdf5 import SaveSpeciesDensityToHDF5, _compute_patch_slice, _normalize_slice
 from lambdapic.core.boundary.cpml import PMLX
 
 from ..core.patch.cpu import (
@@ -260,16 +260,27 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
     """
 
     stage = "current_deposition"
-    def __init__(self, sim: Simulation, species: Species, interval: Union[int, float, Callable] = 100) -> None:
+    def __init__(self, sim: Simulation, species: Species, interval: Union[int, float, Callable] = 100, slice: tuple[int | slice, ...] | None = None) -> None:
         self.species = species
         self.interval = interval
         self.prev_rho = None
         self.species = species
-        if sim.dimension == 2:
-            self.density: NDArray[np.float64] = np.zeros((sim.nx, sim.ny))
+        self.slice = slice
+        if self.slice is not None:
+            if sim.dimension == 2:
+                self._normalized_slice = _normalize_slice(2, self.slice, (sim.nx, sim.ny))
+                sx, sy = self._normalized_slice
+                self.density: NDArray[np.float64] = np.zeros((len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step))))
+            else:
+                self._normalized_slice = _normalize_slice(3, self.slice, (sim.nx, sim.ny, sim.nz))
+                sx, sy, sz = self._normalized_slice
+                self.density: NDArray[np.float64] = np.zeros((len(range(sx.start, sx.stop, sx.step)), len(range(sy.start, sy.stop, sy.step)), len(range(sz.start, sz.stop, sz.step))))
         else:
-            self.density: NDArray[np.float64] = np.zeros((sim.nx, sim.ny, sim.nz))
-        
+            self._normalized_slice = None
+            if sim.dimension == 2:
+                self.density: NDArray[np.float64] = np.zeros((sim.nx, sim.ny))
+            else:
+                self.density: NDArray[np.float64] = np.zeros((sim.nx, sim.ny, sim.nz))
 
         self.prefix = Path('') # for compatibility
 
@@ -290,25 +301,54 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
             local_patches = {p.index: ipatch for ipatch, p in enumerate(sim.patches)}
             
         if rank == 0:
-            # local
-            for ip, p in enumerate(sim.patches):
-                s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
-                          p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch]
-                self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng]
-
-            buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng))
-            for ipatch_x in range(npatch_x):
-                for ipatch_y in range(npatch_y):
-                    s = np.s_[ipatch_x*nx_per_patch:ipatch_x*nx_per_patch+nx_per_patch,\
-                              ipatch_y*ny_per_patch:ipatch_y*ny_per_patch+ny_per_patch]
-                    # local
-                    index = patch_index_map[(ipatch_x, ipatch_y)]
-                    if index in local_patches:
+            if self._normalized_slice is not None:
+                sx, sy = self._normalized_slice
+                # local
+                for ip, p in enumerate(sim.patches):
+                    x_info = _compute_patch_slice(sim.nx, sx, p.ipatch_x * nx_per_patch, nx_per_patch)
+                    y_info = _compute_patch_slice(sim.ny, sy, p.ipatch_y * ny_per_patch, ny_per_patch)
+                    if x_info is None or y_info is None:
                         continue
-                    #remote
-                    else:
+                    local_x, out_x, num_x = x_info
+                    local_y, out_y, num_y = y_info
+                    data = density_per_patch[ip][:-2*ng, :-2*ng][local_x, local_y]
+                    self.density[out_x:out_x+num_x, out_y:out_y+num_y] = data
+
+                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng))
+                for ipatch_x in range(npatch_x):
+                    for ipatch_y in range(npatch_y):
+                        index = patch_index_map[(ipatch_x, ipatch_y)]
+                        if index in local_patches:
+                            continue
                         sim.mpi.comm.Recv(buf, tag=index)
-                        self.density[s] = buf[:-2*ng, :-2*ng]
+                        x_info = _compute_patch_slice(sim.nx, sx, ipatch_x * nx_per_patch, nx_per_patch)
+                        y_info = _compute_patch_slice(sim.ny, sy, ipatch_y * ny_per_patch, ny_per_patch)
+                        if x_info is None or y_info is None:
+                            continue
+                        local_x, out_x, num_x = x_info
+                        local_y, out_y, num_y = y_info
+                        data = buf[:-2*ng, :-2*ng][local_x, local_y]
+                        self.density[out_x:out_x+num_x, out_y:out_y+num_y] = data
+            else:
+                # local
+                for ip, p in enumerate(sim.patches):
+                    s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
+                              p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch]
+                    self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng]
+
+                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng))
+                for ipatch_x in range(npatch_x):
+                    for ipatch_y in range(npatch_y):
+                        s = np.s_[ipatch_x*nx_per_patch:ipatch_x*nx_per_patch+nx_per_patch,\
+                                  ipatch_y*ny_per_patch:ipatch_y*ny_per_patch+ny_per_patch]
+                        # local
+                        index = patch_index_map[(ipatch_x, ipatch_y)]
+                        if index in local_patches:
+                            continue
+                        #remote
+                        else:
+                            sim.mpi.comm.Recv(buf, tag=index)
+                            self.density[s] = buf[:-2*ng, :-2*ng]
         
         else:
             req = []
@@ -339,28 +379,62 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
             local_patches = {p.index: ipatch for ipatch, p in enumerate(sim.patches)}
             
         if rank == 0:
-            # local
-            for ip, p in enumerate(sim.patches):
-                s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
-                          p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch,\
-                          p.ipatch_z*nz_per_patch:p.ipatch_z*nz_per_patch+nz_per_patch]
-                self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng, :-2*ng]
+            if self._normalized_slice is not None:
+                sx, sy, sz = self._normalized_slice
+                # local
+                for ip, p in enumerate(sim.patches):
+                    x_info = _compute_patch_slice(sim.nx, sx, p.ipatch_x * nx_per_patch, nx_per_patch)
+                    y_info = _compute_patch_slice(sim.ny, sy, p.ipatch_y * ny_per_patch, ny_per_patch)
+                    z_info = _compute_patch_slice(sim.nz, sz, p.ipatch_z * nz_per_patch, nz_per_patch)
+                    if x_info is None or y_info is None or z_info is None:
+                        continue
+                    local_x, out_x, num_x = x_info
+                    local_y, out_y, num_y = y_info
+                    local_z, out_z, num_z = z_info
+                    data = density_per_patch[ip][:-2*ng, :-2*ng, :-2*ng][local_x, local_y, local_z]
+                    self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
 
-            buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng, nz_per_patch+2*ng))
-            for ipatch_x in range(npatch_x):
-                for ipatch_y in range(npatch_y):
-                    for ipatch_z in range(npatch_z):
-                        s = np.s_[ipatch_x*nx_per_patch:ipatch_x*nx_per_patch+nx_per_patch,\
-                                  ipatch_y*ny_per_patch:ipatch_y*ny_per_patch+ny_per_patch,\
-                                  ipatch_z*nz_per_patch:ipatch_z*nz_per_patch+nz_per_patch]
-                        # local
-                        index = patch_index_map[(ipatch_x, ipatch_y, ipatch_z)]
-                        if index in local_patches:
-                            continue
-                        #remote
-                        else:
+                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng, nz_per_patch+2*ng))
+                for ipatch_x in range(npatch_x):
+                    for ipatch_y in range(npatch_y):
+                        for ipatch_z in range(npatch_z):
+                            index = patch_index_map[(ipatch_x, ipatch_y, ipatch_z)]
+                            if index in local_patches:
+                                continue
                             sim.mpi.comm.Recv(buf, tag=index)
-                            self.density[s] = buf[:-2*ng, :-2*ng, :-2*ng]
+                            x_info = _compute_patch_slice(sim.nx, sx, ipatch_x * nx_per_patch, nx_per_patch)
+                            y_info = _compute_patch_slice(sim.ny, sy, ipatch_y * ny_per_patch, ny_per_patch)
+                            z_info = _compute_patch_slice(sim.nz, sz, ipatch_z * nz_per_patch, nz_per_patch)
+                            if x_info is None or y_info is None or z_info is None:
+                                continue
+                            local_x, out_x, num_x = x_info
+                            local_y, out_y, num_y = y_info
+                            local_z, out_z, num_z = z_info
+                            data = buf[:-2*ng, :-2*ng, :-2*ng][local_x, local_y, local_z]
+                            self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+            else:
+                # local
+                for ip, p in enumerate(sim.patches):
+                    s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
+                              p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch,\
+                              p.ipatch_z*nz_per_patch:p.ipatch_z*nz_per_patch+nz_per_patch]
+                    self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng, :-2*ng]
+
+                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng, nz_per_patch+2*ng))
+                for ipatch_x in range(npatch_x):
+                    for ipatch_y in range(npatch_y):
+                        for ipatch_z in range(npatch_z):
+                            s = np.s_[ipatch_x*nx_per_patch:ipatch_x*nx_per_patch+nx_per_patch,\
+                                      ipatch_y*ny_per_patch:ipatch_y*ny_per_patch+ny_per_patch,\
+                                      ipatch_z*nz_per_patch:ipatch_z*nz_per_patch+nz_per_patch]
+                            # local
+                            index = patch_index_map[(ipatch_x, ipatch_y, ipatch_z)]
+                            if index in local_patches:
+                                continue
+                            #remote
+                            else:
+                                sim.mpi.comm.Recv(buf, tag=index)
+                                self.density[s] = buf[:-2*ng, :-2*ng, :-2*ng]
         
         else:
             req = []

--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -290,7 +290,6 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
         
         nx_per_patch = sim.nx_per_patch
         ny_per_patch = sim.ny_per_patch
-        ng = sim.n_guard
         npatch_x = sim.npatch_x
         npatch_y = sim.npatch_y
 
@@ -311,32 +310,30 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
                         continue
                     local_x, out_x, num_x = x_info
                     local_y, out_y, num_y = y_info
-                    data = density_per_patch[ip][:-2*ng, :-2*ng][local_x, local_y]
-                    self.density[out_x:out_x+num_x, out_y:out_y+num_y] = data
+                    self.density[out_x:out_x+num_x, out_y:out_y+num_y] = density_per_patch[ip]
 
-                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng))
+                buf = np.zeros((nx_per_patch, ny_per_patch))
                 for ipatch_x in range(npatch_x):
                     for ipatch_y in range(npatch_y):
-                        index = patch_index_map[(ipatch_x, ipatch_y)]
-                        if index in local_patches:
-                            continue
-                        sim.mpi.comm.Recv(buf, tag=index)
                         x_info = _compute_patch_slice(sim.nx, sx, ipatch_x * nx_per_patch, nx_per_patch)
                         y_info = _compute_patch_slice(sim.ny, sy, ipatch_y * ny_per_patch, ny_per_patch)
                         if x_info is None or y_info is None:
                             continue
+                        index = patch_index_map[(ipatch_x, ipatch_y)]
+                        if index in local_patches:
+                            continue
+                        sim.mpi.comm.Recv(buf, tag=index)
                         local_x, out_x, num_x = x_info
                         local_y, out_y, num_y = y_info
-                        data = buf[:-2*ng, :-2*ng][local_x, local_y]
-                        self.density[out_x:out_x+num_x, out_y:out_y+num_y] = data
+                        self.density[out_x:out_x+num_x, out_y:out_y+num_y] = buf[:num_x, :num_y]
             else:
                 # local
                 for ip, p in enumerate(sim.patches):
                     s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
                               p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch]
-                    self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng]
+                    self.density[s] = density_per_patch[ip]
 
-                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng))
+                buf = np.zeros((nx_per_patch, ny_per_patch))
                 for ipatch_x in range(npatch_x):
                     for ipatch_y in range(npatch_y):
                         s = np.s_[ipatch_x*nx_per_patch:ipatch_x*nx_per_patch+nx_per_patch,\
@@ -348,11 +345,13 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
                         #remote
                         else:
                             sim.mpi.comm.Recv(buf, tag=index)
-                            self.density[s] = buf[:-2*ng, :-2*ng]
+                            self.density[s] = buf
         
         else:
             req = []
             for ip, p in enumerate(sim.patches):
+                if density_per_patch[ip].size == 0:
+                    continue
                 req_ = sim.mpi.comm.Isend(density_per_patch[ip], dest=0, tag=p.index)
                 req.append(req_)
             for req_ in req:
@@ -367,7 +366,6 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
         nx_per_patch = sim.nx_per_patch
         ny_per_patch = sim.ny_per_patch
         nz_per_patch = sim.nz_per_patch
-        ng = sim.n_guard
         npatch_x = sim.npatch_x
         npatch_y = sim.npatch_y
         npatch_z = sim.npatch_z
@@ -391,36 +389,34 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
                     local_x, out_x, num_x = x_info
                     local_y, out_y, num_y = y_info
                     local_z, out_z, num_z = z_info
-                    data = density_per_patch[ip][:-2*ng, :-2*ng, :-2*ng][local_x, local_y, local_z]
-                    self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+                    self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = density_per_patch[ip]
 
-                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng, nz_per_patch+2*ng))
+                buf = np.zeros((nx_per_patch, ny_per_patch, nz_per_patch))
                 for ipatch_x in range(npatch_x):
                     for ipatch_y in range(npatch_y):
                         for ipatch_z in range(npatch_z):
-                            index = patch_index_map[(ipatch_x, ipatch_y, ipatch_z)]
-                            if index in local_patches:
-                                continue
-                            sim.mpi.comm.Recv(buf, tag=index)
                             x_info = _compute_patch_slice(sim.nx, sx, ipatch_x * nx_per_patch, nx_per_patch)
                             y_info = _compute_patch_slice(sim.ny, sy, ipatch_y * ny_per_patch, ny_per_patch)
                             z_info = _compute_patch_slice(sim.nz, sz, ipatch_z * nz_per_patch, nz_per_patch)
                             if x_info is None or y_info is None or z_info is None:
                                 continue
+                            index = patch_index_map[(ipatch_x, ipatch_y, ipatch_z)]
+                            if index in local_patches:
+                                continue
+                            sim.mpi.comm.Recv(buf, tag=index)
                             local_x, out_x, num_x = x_info
                             local_y, out_y, num_y = y_info
                             local_z, out_z, num_z = z_info
-                            data = buf[:-2*ng, :-2*ng, :-2*ng][local_x, local_y, local_z]
-                            self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = data
+                            self.density[out_x:out_x+num_x, out_y:out_y+num_y, out_z:out_z+num_z] = buf[:num_x, :num_y, :num_z]
             else:
                 # local
                 for ip, p in enumerate(sim.patches):
                     s = np.s_[p.ipatch_x*nx_per_patch:p.ipatch_x*nx_per_patch+nx_per_patch,\
                               p.ipatch_y*ny_per_patch:p.ipatch_y*ny_per_patch+ny_per_patch,\
                               p.ipatch_z*nz_per_patch:p.ipatch_z*nz_per_patch+nz_per_patch]
-                    self.density[s] = density_per_patch[ip][:-2*ng, :-2*ng, :-2*ng]
+                    self.density[s] = density_per_patch[ip]
 
-                buf = np.zeros((nx_per_patch+2*ng, ny_per_patch+2*ng, nz_per_patch+2*ng))
+                buf = np.zeros((nx_per_patch, ny_per_patch, nz_per_patch))
                 for ipatch_x in range(npatch_x):
                     for ipatch_y in range(npatch_y):
                         for ipatch_z in range(npatch_z):
@@ -434,11 +430,13 @@ class ExtractSpeciesDensity(SaveSpeciesDensityToHDF5):
                             #remote
                             else:
                                 sim.mpi.comm.Recv(buf, tag=index)
-                                self.density[s] = buf[:-2*ng, :-2*ng, :-2*ng]
+                                self.density[s] = buf
         
         else:
             req = []
             for ip, p in enumerate(sim.patches):
+                if density_per_patch[ip].size == 0:
+                    continue
                 req_ = sim.mpi.comm.Isend(density_per_patch[ip], dest=0, tag=p.index)
                 req.append(req_)
             for req_ in req:

--- a/src/lambdapic/callback/utils.py
+++ b/src/lambdapic/callback/utils.py
@@ -757,8 +757,9 @@ class SetTemperature(Callback):
         temperature (float): Temperature in units of eV.
         interval (int or callable): Frequency (in timesteps) or callable(sim) for when to apply, defaults to run at the first timestep only once.
     """
-    stage: str = "start"
+    DEFAULT_STAGE = "init"
     def __init__(self, species: Species, temperature: float|int|List[float|int], interval: Union[int, float, Callable]|None = None) -> None:
+        self.stage = self.DEFAULT_STAGE
         self.species = species
 
         if isinstance(temperature, (float, int)):
@@ -893,7 +894,7 @@ class LoadParticles(Callback):
             Controls memory usage during loading. Default is 10,000 particles per batch.
             
     Example:
-        >>> # Load electrons from an HDF5 file at simulation start
+        >>> # Load electrons from an HDF5 file after simulation initialization
         >>> load_ele = LoadParticles(ele, "particles.h5")
         >>> sim.run(1000, callbacks=[load_ele])
         
@@ -902,9 +903,9 @@ class LoadParticles(Callback):
         - Particles are automatically distributed to patches based on their spatial coordinates
         - Batch processing reduces memory usage for large particle datasets
     """
-    stage: str = "start"
+    DEFAULT_STAGE = "init"
     def __init__(self, species: Species, file: str|Path, interval: Union[int, float, Callable]|None = None) -> None:
-        
+        self.stage = self.DEFAULT_STAGE
         self.species = species
         self.file = file
 

--- a/tests/test_hdf5_callback.py
+++ b/tests/test_hdf5_callback.py
@@ -2,7 +2,7 @@ import pytest
 import h5py
 import os
 import numpy as np
-from lambdapic.simulation import Simulation
+from lambdapic.simulation import Simulation, Simulation3D
 from lambdapic.core.species import Electron
 from lambdapic.callback.hdf5 import (
     SaveFieldsToHDF5,
@@ -141,3 +141,257 @@ def test_hdf5_particles_callback_2d(tmp_path):
         # Verify length matches expected particles per cell
         expected_particles = sim.nx * sim.ny * electrons.ppc
         assert x_len == expected_particles
+
+
+# =============================================================================
+# 2D Slice tests for SaveFieldsToHDF5
+# =============================================================================
+
+def test_hdf5_field_callback_2d_slice_none(tmp_path):
+    """Test SaveFieldsToHDF5 with no slice (full domain) in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=None, components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 32)
+        ref = np.zeros((32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref)
+        assert 'slice' not in f.attrs
+
+
+def test_hdf5_field_callback_2d_slice_int(tmp_path):
+    """Test SaveFieldsToHDF5 with an integer slice along y in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, 5], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 1)
+        ref = np.zeros((32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch]
+        np.testing.assert_array_equal(f['ex'][:, 0], ref[:, 5])
+        assert f.attrs['slice'] == '[:, 5]'
+
+
+def test_hdf5_field_callback_2d_slice_stepped(tmp_path):
+    """Test SaveFieldsToHDF5 with stepped slicing in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[::2, ::3], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (16, 11)
+        ref = np.zeros((32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref[::2, ::3])
+        assert f.attrs['slice'] == '[::2, ::3]'
+
+
+def test_hdf5_field_callback_2d_slice_tail(tmp_path):
+    """Test SaveFieldsToHDF5 with a tail slice (first half omitted) in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[16:, :], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (16, 32)
+        ref = np.zeros((32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref[16:, :])
+
+
+# =============================================================================
+# 3D Slice tests for SaveFieldsToHDF5
+# =============================================================================
+
+def test_hdf5_field_callback_3d_slice_none(tmp_path):
+    """Test SaveFieldsToHDF5 with no slice (full domain) in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :, :] = p.ipatch_x * 100 + p.ipatch_y * 10 + p.ipatch_z
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out3d'), interval=1, slice=None, components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out3d' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 32, 32)
+        ref = np.zeros((32, 32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            iz = p.ipatch_z * sim.nz_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch, iz:iz + sim.nz_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref)
+        assert 'slice' not in f.attrs
+
+
+def test_hdf5_field_callback_3d_slice_plane(tmp_path):
+    """Test SaveFieldsToHDF5 with a plane slice in 3D (single z index)."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :, :] = p.ipatch_x * 100 + p.ipatch_y * 10 + p.ipatch_z
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[:, :, 10], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out3d' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 32, 1)
+        ref = np.zeros((32, 32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            iz = p.ipatch_z * sim.nz_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch, iz:iz + sim.nz_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        np.testing.assert_array_equal(f['ex'][:, :, 0], ref[:, :, 10])
+        assert f.attrs['slice'] == '[:, :, 10]'
+
+
+def test_hdf5_field_callback_3d_slice_stepped(tmp_path):
+    """Test SaveFieldsToHDF5 with stepped slicing in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :, :] = p.ipatch_x * 100 + p.ipatch_y * 10 + p.ipatch_z
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[::2, ::2, ::5], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out3d' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (16, 16, 7)
+        ref = np.zeros((32, 32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            iz = p.ipatch_z * sim.nz_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch, iz:iz + sim.nz_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref[::2, ::2, ::5])
+        assert f.attrs['slice'] == '[::2, ::2, ::5]'
+
+
+def test_hdf5_field_callback_3d_slice_tail(tmp_path):
+    """Test SaveFieldsToHDF5 with a tail slice in 3D (first half along x omitted)."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :, :] = p.ipatch_x * 100 + p.ipatch_y * 10 + p.ipatch_z
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[16:, :, :], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out3d' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (16, 32, 32)
+        ref = np.zeros((32, 32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            iz = p.ipatch_z * sim.nz_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch, iz:iz + sim.nz_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch, :sim.nz_per_patch]
+        np.testing.assert_array_equal(f['ex'][:], ref[16:, :, :])
+
+
+# =============================================================================
+# Invalid slice edge cases for SaveFieldsToHDF5
+# =============================================================================
+
+def test_hdf5_field_callback_invalid_slice_type(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for invalid slice element type (list)."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=([0, 1], slice(None)), components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_ellipsis(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for Ellipsis in slice."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[..., 10], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_neg_step(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for negative step in slice."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[::-1, :, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_axis_mismatch(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for axis count mismatch."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_empty(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for empty slice (start >= stop)."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[0:0, :, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_newaxis(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for None/newaxis in slice."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[None, :, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_zero_step(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for zero step in slice."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, ::0, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)
+
+
+def test_hdf5_field_callback_invalid_slice_out_of_range(tmp_path):
+    """Test SaveFieldsToHDF5 raises ValueError for out-of-range slice start."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    sim.initialize()
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[999:, :, :], components=['ex'])
+    with pytest.raises(ValueError):
+        cb._call(sim)

--- a/tests/test_hdf5_callback.py
+++ b/tests/test_hdf5_callback.py
@@ -9,6 +9,7 @@ from lambdapic.callback.hdf5 import (
     SaveSpeciesDensityToHDF5,
     SaveParticlesToHDF5
 )
+from lambdapic.callback.utils import ExtractSpeciesDensity
 
 def test_hdf5_field_callback_2d(tmp_path):
     """Test saving field data to HDF5 in 2D simulation."""
@@ -495,3 +496,75 @@ def test_hdf5_field_callback_invalid_slice_out_of_range(tmp_path):
     cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[999:, :, :], components=['ex'])
     with pytest.raises(ValueError):
         cb._call(sim)
+
+
+def test_extract_density_2d_slice_none(tmp_path):
+    """Test ExtractSpeciesDensity with slice=None (full domain) in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    sim.run(1, callbacks=[cb])
+    assert cb.density.shape == (32, 32)
+    assert np.isfinite(cb.density).all()
+    assert cb.density.max() > 0
+
+
+def test_extract_density_2d_slice_int(tmp_path):
+    """Test ExtractSpeciesDensity with int slice in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb_full = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    cb_slice = ExtractSpeciesDensity(sim, electrons, interval=1, slice=np.s_[:, 5])
+    sim.run(1, callbacks=[cb_full, cb_slice])
+    assert cb_slice.density.shape == (32, 1)
+    assert np.allclose(cb_slice.density, cb_full.density[:, 5:6])
+
+
+def test_extract_density_2d_slice_stepped(tmp_path):
+    """Test ExtractSpeciesDensity with stepped slice in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb_full = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    cb_slice = ExtractSpeciesDensity(sim, electrons, interval=1, slice=np.s_[::2, ::3])
+    sim.run(1, callbacks=[cb_full, cb_slice])
+    assert cb_slice.density.shape == (16, 11)
+    assert np.allclose(cb_slice.density, cb_full.density[::2, ::3])
+
+
+def test_extract_density_3d_slice_none(tmp_path):
+    """Test ExtractSpeciesDensity with slice=None (full domain) in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    sim.run(1, callbacks=[cb])
+    assert cb.density.shape == (32, 32, 32)
+    assert np.isfinite(cb.density).all()
+    assert cb.density.max() > 0
+
+
+def test_extract_density_3d_slice_plane(tmp_path):
+    """Test ExtractSpeciesDensity with plane slice in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb_full = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    cb_slice = ExtractSpeciesDensity(sim, electrons, interval=1, slice=np.s_[:, :, 10])
+    sim.run(1, callbacks=[cb_full, cb_slice])
+    assert cb_slice.density.shape == (32, 32, 1)
+    assert np.allclose(cb_slice.density, cb_full.density[:, :, 10:11])
+
+
+def test_extract_density_3d_slice_stepped(tmp_path):
+    """Test ExtractSpeciesDensity with stepped slice in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+    cb_full = ExtractSpeciesDensity(sim, electrons, interval=1, slice=None)
+    cb_slice = ExtractSpeciesDensity(sim, electrons, interval=1, slice=np.s_[::2, ::2, ::5])
+    sim.run(1, callbacks=[cb_full, cb_slice])
+    assert cb_slice.density.shape == (16, 16, 7)
+    assert np.allclose(cb_slice.density, cb_full.density[::2, ::2, ::5])

--- a/tests/test_hdf5_callback.py
+++ b/tests/test_hdf5_callback.py
@@ -85,6 +85,106 @@ def test_hdf5_species_callback_2d(tmp_path):
         assert 'density' in f
         assert f.attrs['species'] == 'electrons'
 
+# =============================================================================
+# 2D Slice tests for SaveSpeciesDensityToHDF5
+# =============================================================================
+
+def test_hdf5_density_callback_2d_slice_none(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with slice=None (full domain) in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out'), interval=1, slice=None)
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out' / f'electrons_000000.h5', 'r') as f:
+        dset = f['density']
+        assert dset.shape == (32, 32)
+        assert dset[:].size == 32 * 32
+        assert 'slice' not in f.attrs
+        assert f.attrs['species'] == 'electrons'
+
+
+def test_hdf5_density_callback_2d_slice_int(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with an integer slice along y in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, 5])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (32, 1)
+        assert f['density'][:].size == 32
+        assert f.attrs['slice'] == '[:, 5]'
+
+
+def test_hdf5_density_callback_2d_slice_stepped(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with stepped slicing in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[::2, ::3])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (16, 11)
+        assert f['density'][:].size == 176
+        assert f.attrs['slice'] == '[::2, ::3]'
+
+
+# =============================================================================
+# 3D Slice tests for SaveSpeciesDensityToHDF5
+# =============================================================================
+
+def test_hdf5_density_callback_3d_slice_none(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with slice=None (full domain) in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out3d'), interval=1, slice=None)
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out3d' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (32, 32, 32)
+        assert f['density'][:].size == 32 * 32 * 32
+        assert 'slice' not in f.attrs
+
+
+def test_hdf5_density_callback_3d_slice_plane(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with a plane slice in 3D (single z index)."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[:, :, 10])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out3d' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (32, 32, 1)
+        assert f['density'][:].size == 32 * 32
+        assert f.attrs['slice'] == '[:, :, 10]'
+
+
+def test_hdf5_density_callback_3d_slice_stepped(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with stepped slicing in 3D."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[::2, ::2, ::5])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out3d' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (16, 16, 7)
+        assert f['density'][:].size == 1792
+        assert f.attrs['slice'] == '[::2, ::2, ::5]'
+
+
 def test_hdf5_particles_callback_2d(tmp_path):
     """Test saving particle data to HDF5 in 2D simulation."""
     sim = Simulation(

--- a/tests/test_hdf5_callback.py
+++ b/tests/test_hdf5_callback.py
@@ -568,3 +568,85 @@ def test_extract_density_3d_slice_stepped(tmp_path):
     sim.run(1, callbacks=[cb_full, cb_slice])
     assert cb_slice.density.shape == (16, 16, 7)
     assert np.allclose(cb_slice.density, cb_full.density[::2, ::2, ::5])
+
+
+def test_hdf5_field_callback_2d_slice_negative_int(tmp_path):
+    """Test SaveFieldsToHDF5 with a negative integer slice index in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, -1], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 1)
+        ref = np.zeros((32, 32))
+        for p in sim.patches:
+            ix = p.ipatch_x * sim.nx_per_patch
+            iy = p.ipatch_y * sim.ny_per_patch
+            ref[ix:ix + sim.nx_per_patch, iy:iy + sim.ny_per_patch] = p.fields.ex[:sim.nx_per_patch, :sim.ny_per_patch]
+        np.testing.assert_array_equal(f['ex'][:, 0], ref[:, -1])
+        assert f.attrs['slice'] == '[:, 31]'
+
+
+def test_hdf5_density_callback_2d_slice_negative_int(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with a negative integer slice index in 2D."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, -1])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (32, 1)
+        assert f.attrs['slice'] == '[:, 31]'
+
+
+def test_hdf5_density_callback_3d_slice_tail(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 with a tail slice in 3D (first half along x omitted)."""
+    sim = Simulation3D(nx=32, ny=32, nz=32, dx=0.1, dy=0.1, dz=0.1, npatch_x=2, npatch_y=2, npatch_z=2)
+    electrons = Electron(name="electrons", density=lambda x, y, z: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out3d'), interval=1, slice=np.s_[16:, :, :])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out3d' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (16, 32, 32)
+        assert f.attrs['slice'] == '[16:, :, :]'
+
+
+def test_hdf5_field_callback_numpy_int_slice(tmp_path):
+    """Test SaveFieldsToHDF5 accepts numpy integer types in slice specification."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    sim.initialize()
+    for p in sim.patches:
+        p.fields.ex[:, :] = p.ipatch_x * 10 + p.ipatch_y
+
+    # Use np.int64 explicitly to verify the bug fix
+    idx = np.int64(5)
+    cb = SaveFieldsToHDF5(prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, idx], components=['ex'])
+    cb._call(sim)
+
+    with h5py.File(tmp_path / 'out' / '000000.h5', 'r') as f:
+        assert f['ex'].shape == (32, 1)
+        assert f.attrs['slice'] == '[:, 5]'
+
+
+def test_hdf5_density_callback_numpy_int_slice(tmp_path):
+    """Test SaveSpeciesDensityToHDF5 accepts numpy integer types in slice specification."""
+    sim = Simulation(nx=32, ny=32, dx=0.1, dy=0.1, npatch_x=2, npatch_y=2, dt_cfl=0.95)
+    electrons = Electron(name="electrons", density=lambda x, y: 1.0, ppc=4)
+    sim.add_species([electrons])
+
+    # Use np.int64 explicitly to verify the bug fix
+    idx = np.int64(5)
+    cb = SaveSpeciesDensityToHDF5(species=electrons, prefix=str(tmp_path / 'out'), interval=1, slice=np.s_[:, idx])
+    sim.run(1, callbacks=[cb])
+
+    with h5py.File(tmp_path / 'out' / 'electrons_000000.h5', 'r') as f:
+        assert f['density'].shape == (32, 1)
+        assert f.attrs['slice'] == '[:, 5]'


### PR DESCRIPTION
## Summary
Add `np.s_`-style slice support to HDF5 field/density callbacks and extract a shared `_HDF5SliceWriter` class to eliminate code duplication.
## Changes
- **feat(hdf5)**: `SaveFieldsToHDF5` and `SaveSpeciesDensityToHDF5` accept a `slice=` argument (e.g. `slice=np.s_[:, :, 100]`, `slice=np.s_[::2, ::2, ::5]`)
- **feat(utils)**: `ExtractSpeciesDensity` also supports slicing
- **refactor(hdf5)**: Extract `_HDF5SliceWriter` to unify 2D/3D/MPI/non-MPI write paths
- **fix(hdf5)**: Add MPI barriers after dataset creation and file writes to prevent partial-rank output
- **refactor(hdf5)**: `_compute_density` only computes density for slice-relevant patch portions
- **test(hdf5)**: Add tests for full domain, plane slices, stepped slices, negative indices, and numpy integer types
## Review fixes (this PR)
- fix(restart): update docstring and use `DEFAULT_STAGE` pattern
- fix(hdf5): remove redundant `os.makedirs` calls and unify stage pattern
## Notes
- `SaveFieldsToHDF5`, `SaveParticlesToHDF5`, `PlotFields`, and `RestartDump` now run at stage `"end"` (changed from `"maxwell_2"`). This was intentional in the original internal branch.
EOF