### PR TITLE
perf(pusher): optimize 2D/3D Boris pusher and current deposit

### DIFF
--- a/src/lambdapic/core/current/current_deposit.h
+++ b/src/lambdapic/core/current/current_deposit.h
@@ -205,4 +205,123 @@ __attribute__((always_inline)) inline static void current_deposit_2d_fast(
     }
 }
 
+__attribute__((always_inline)) inline static void current_deposit_3d_fast(
+    double* restrict rho, double* restrict jx, double* restrict jy, double* restrict jz,
+    double x, double y, double z,
+    double ux, double uy, double uz, double inv_gamma,
+    npy_intp nx, npy_intp ny, npy_intp nz,
+    double dx, double dy, double dz, double x0, double y0, double z0, double dt, double w,
+    double q_over_dx_dy_dz, double q_over_dy_dz_dt, double q_over_dx_dz_dt, double q_over_dx_dy_dt
+) {
+    double vx = ux * LIGHT_SPEED * inv_gamma;
+    double vy = uy * LIGHT_SPEED * inv_gamma;
+    double vz = uz * LIGHT_SPEED * inv_gamma;
+    double x_old = x - vx * 0.5 * dt - x0;
+    double x_adv = x + vx * 0.5 * dt - x0;
+    double y_old = y - vy * 0.5 * dt - y0;
+    double y_adv = y + vy * 0.5 * dt - y0;
+    double z_old = z - vz * 0.5 * dt - z0;
+    double z_adv = z + vz * 0.5 * dt - z0;
+
+    double x_over_dx0 = x_old / dx;
+    double y_over_dy0 = y_old / dy;
+    double z_over_dz0 = z_old / dz;
+    double x_over_dx1 = x_adv / dx;
+    double y_over_dy1 = y_adv / dy;
+    double z_over_dz1 = z_adv / dz;
+
+    int ix0, iy0, iz0, ix1, iy1, iz1;
+    if (x_old >= 0 && x_adv >= 0 && y_old >= 0 && y_adv >= 0 && z_old >= 0 && z_adv >= 0) {
+        ix0 = (int)(x_over_dx0 + 0.5);
+        iy0 = (int)(y_over_dy0 + 0.5);
+        iz0 = (int)(z_over_dz0 + 0.5);
+        ix1 = (int)(x_over_dx1 + 0.5);
+        iy1 = (int)(y_over_dy1 + 0.5);
+        iz1 = (int)(z_over_dz1 + 0.5);
+    } else {
+        ix0 = (int)floor(x_over_dx0 + 0.5);
+        iy0 = (int)floor(y_over_dy0 + 0.5);
+        iz0 = (int)floor(z_over_dz0 + 0.5);
+        ix1 = (int)floor(x_over_dx1 + 0.5);
+        iy1 = (int)floor(y_over_dy1 + 0.5);
+        iz1 = (int)floor(z_over_dz1 + 0.5);
+    }
+
+    double S0x[5], S0y[5], S0z[5];
+    calculate_S(ix0 - x_over_dx0, 0, S0x);
+    calculate_S(iy0 - y_over_dy0, 0, S0y);
+    calculate_S(iz0 - z_over_dz0, 0, S0z);
+
+    int dcell_x = ix1 - ix0;
+    int dcell_y = iy1 - iy0;
+    int dcell_z = iz1 - iz0;
+
+    double S1x[5], S1y[5], S1z[5], DSx[5], DSy[5], DSz[5];
+    calculate_S(ix1 - x_over_dx1, dcell_x, S1x);
+    calculate_S(iy1 - y_over_dy1, dcell_y, S1y);
+    calculate_S(iz1 - z_over_dz1, dcell_z, S1z);
+
+    for (int i = 0; i < 5; i++) {
+        DSx[i] = S1x[i] - S0x[i];
+        DSy[i] = S1y[i] - S0y[i];
+        DSz[i] = S1z[i] - S0z[i];
+    }
+
+    double charge_density = q_over_dx_dy_dz * w;
+    double factor_dx = q_over_dy_dz_dt * w;
+    double factor_dy = q_over_dx_dz_dt * w;
+    double factor_dz = q_over_dx_dy_dt * w;
+
+    int i_start = dcell_x < 0 ? 0 : 1;
+    int i_end = dcell_x > 0 ? 5 : 4;
+    int j_start = dcell_y < 0 ? 0 : 1;
+    int j_end = dcell_y > 0 ? 5 : 4;
+    int k_start = dcell_z < 0 ? 0 : 1;
+    int k_end = dcell_z > 0 ? 5 : 4;
+
+    double jx_buff[5][5] = {{0}};
+    npy_intp ny_nz = ny * nz;
+
+    for (int i = i_start; i < i_end; i++) {
+        int ix = ix0 + (i - 2);
+        if (ix < 0) ix = nx + ix;
+
+        double a_x = S0x[i] + 0.5 * DSx[i];
+        double c_x = 0.5 * S0x[i] + one_third * DSx[i];
+        double factor_dx_DSx_i = factor_dx * DSx[i];
+
+        double jy_buff[5] = {0};
+
+        for (int j = j_start; j < j_end; j++) {
+            int iy = iy0 + (j - 2);
+            if (iy < 0) iy = ny + iy;
+
+            double a_y = S0y[j] + 0.5 * DSy[j];
+            double c_y = 0.5 * S0y[j] + one_third * DSy[j];
+            double factor_dy_DSy_j = factor_dy * DSy[j];
+            double term_jz_ij = a_x * S0y[j] + c_x * DSy[j];
+
+            double jz_buff = 0;
+
+            for (int k = k_start; k < k_end; k++) {
+                int iz = iz0 + (k - 2);
+                if (iz < 0) iz = nz + iz;
+
+                double term_jx = a_y * S0z[k] + c_y * DSz[k];
+                double term_jy = a_x * S0z[k] + c_x * DSz[k];
+
+                jx_buff[k][j] -= factor_dx_DSx_i * term_jx;
+                jy_buff[k] -= factor_dy_DSy_j * term_jy;
+                jz_buff -= factor_dz * DSz[k] * term_jz_ij;
+
+                npy_intp idx = iz + iy * nz + ix * ny_nz;
+                jx[idx] += jx_buff[k][j];
+                jy[idx] += jy_buff[k];
+                jz[idx] += jz_buff;
+                rho[idx] += charge_density * S1x[i] * S1y[j] * S1z[k];
+            }
+        }
+    }
+}
+
 #endif /* CURRENT_DEPOSIT_H */

--- a/src/lambdapic/core/current/current_deposit.h
+++ b/src/lambdapic/core/current/current_deposit.h
@@ -4,7 +4,7 @@
 #include <math.h>
 #include "../utils/cutils.h"
 
-static void calculate_S(double delta, int shift, double* S) {
+static inline void calculate_S(double delta, int shift, double* S) {
     double delta2 = delta * delta;
 
     double delta_minus = 0.5 * (delta2 + delta + 0.25);
@@ -22,83 +22,185 @@ static void calculate_S(double delta, int shift, double* S) {
     S[4] = positive * delta_positive;
 }
 
-inline static void current_deposit_2d(
-    double* rho, double* jx, double* jy, double* jz,
+__attribute__((always_inline)) inline static void current_deposit_2d(
+    double* restrict rho, double* restrict jx, double* restrict jy, double* restrict jz,
     double x, double y,
     double ux, double uy, double uz, double inv_gamma,
     npy_intp nx, npy_intp ny,
     double dx, double dy, double x0, double y0, double dt, double w, double q
 ) {
-    double vx, vy, vz;
-    double x_old, y_old, x_adv, y_adv;
-    double S0x[5], S1x[5], S0y[5], S1y[5], DSx[5], DSy[5], jx_buff[5];
+    double vx = ux * LIGHT_SPEED * inv_gamma;
+    double vy = uy * LIGHT_SPEED * inv_gamma;
+    double vz = uz * LIGHT_SPEED * inv_gamma;
+    double x_old = x - vx * 0.5 * dt - x0;
+    double y_old = y - vy * 0.5 * dt - y0;
+    double x_adv = x + vx * 0.5 * dt - x0;
+    double y_adv = y + vy * 0.5 * dt - y0;
 
-    npy_intp i, j;
+    double x_over_dx0 = x_old / dx;
+    double y_over_dy0 = y_old / dy;
+    double x_over_dx1 = x_adv / dx;
+    double y_over_dy1 = y_adv / dy;
 
-    npy_intp dcell_x, dcell_y, ix0, iy0, ix1, iy1, ix, iy;
+    int ix0, iy0, ix1, iy1;
+    // Fast path: for non-negative coordinates, (int) is equivalent to floor
+    if (x_old >= 0 && x_adv >= 0 && y_old >= 0 && y_adv >= 0) {
+        ix0 = (int)(x_over_dx0 + 0.5);
+        iy0 = (int)(y_over_dy0 + 0.5);
+        ix1 = (int)(x_over_dx1 + 0.5);
+        iy1 = (int)(y_over_dy1 + 0.5);
+    } else {
+        ix0 = (int)floor(x_over_dx0 + 0.5);
+        iy0 = (int)floor(y_over_dy0 + 0.5);
+        ix1 = (int)floor(x_over_dx1 + 0.5);
+        iy1 = (int)floor(y_over_dy1 + 0.5);
+    }
 
-    double x_over_dx0, x_over_dx1, y_over_dy0, y_over_dy1;
-
-    double charge_density, factor, jy_buff;
-
-    vx = ux * LIGHT_SPEED * inv_gamma;
-    vy = uy * LIGHT_SPEED * inv_gamma;
-    vz = uz * LIGHT_SPEED * inv_gamma;
-    x_old = x - vx * 0.5 * dt - x0;
-    y_old = y - vy * 0.5 * dt - y0;
-    x_adv = x + vx * 0.5 * dt - x0;
-    y_adv = y + vy * 0.5 * dt - y0;
-
-    x_over_dx0 = x_old / dx;
-    ix0 = (int)floor(x_over_dx0 + 0.5);
-    y_over_dy0 = y_old / dy;
-    iy0 = (int)floor(y_over_dy0 + 0.5);
-
+    double S0x[5], S0y[5];
     calculate_S(ix0 - x_over_dx0, 0, S0x);
     calculate_S(iy0 - y_over_dy0, 0, S0y);
 
-    x_over_dx1 = x_adv / dx;
-    ix1 = (int)floor(x_over_dx1 + 0.5);
-    dcell_x = ix1 - ix0;
+    int dcell_x = ix1 - ix0;
+    int dcell_y = iy1 - iy0;
 
-    y_over_dy1 = y_adv / dy;
-    iy1 = (int)floor(y_over_dy1 + 0.5);
-    dcell_y = iy1 - iy0;
-
+    double S1x[5], S1y[5], DSx[5], DSy[5];
     calculate_S(ix1 - x_over_dx1, dcell_x, S1x);
     calculate_S(iy1 - y_over_dy1, dcell_y, S1y);
 
+    npy_intp i, j;
     for (i = 0; i < 5; i++) {
         DSx[i] = S1x[i] - S0x[i];
         DSy[i] = S1y[i] - S0y[i];
-        jx_buff[i] = 0;
     }
 
-    charge_density = q * w / (dx * dy);
-    factor = charge_density / dt;
+    double charge_density = q * w / (dx * dy);
+    double factor = charge_density / dt;
+    double factor_dx = factor * dx;
+    double factor_dy = factor * dy;
+    double factor_dt_vz = factor * dt * vz;
+    const double one_twelfth = 1.0 / 12.0;
 
-    for (i = fmin(1, 1 + dcell_x); i < fmax(4, 4 + dcell_x); i++) {
-        ix = ix0 + (i - 2);
-        if (ix < 0) {
-            ix = nx + ix;
+    int i_start = dcell_x < 0 ? 0 : 1;
+    int i_end = dcell_x > 0 ? 5 : 4;
+    int j_start = dcell_y < 0 ? 0 : 1;
+    int j_end = dcell_y > 0 ? 5 : 4;
+
+    double jx_buff[5] = {0, 0, 0, 0, 0};
+
+    for (i = i_start; i < i_end; i++) {
+        int ix = ix0 + (i - 2);
+        if (ix < 0) ix = nx + ix;
+        double jy_buff = 0.0;
+        npy_intp ix_ny = ix * ny;
+        double a = S0x[i] + 0.5 * DSx[i];
+        double factor_dx_DSx_i = factor_dx * DSx[i];
+        double one_twelfth_DSx_i = one_twelfth * DSx[i];
+        for (j = j_start; j < j_end; j++) {
+            int iy = iy0 + (j - 2);
+            if (iy < 0) iy = ny + iy;
+            double b = S0y[j] + 0.5 * DSy[j];
+            double wy = DSy[j] * a;
+            double wz = a * b + one_twelfth_DSx_i * DSy[j];
+
+            jx_buff[j] -= factor_dx_DSx_i * b;
+            jy_buff -= factor_dy * wy;
+
+            npy_intp idx = iy + ix_ny;
+            jx[idx] += jx_buff[j];
+            jy[idx] += jy_buff;
+            jz[idx] += factor_dt_vz * wz;
+            rho[idx] += charge_density * S1x[i] * S1y[j];
         }
-        jy_buff = 0.0;
-        for (j = fmin(1, 1 + dcell_y); j < fmax(4, 4 + dcell_y); j++) {
-            iy = iy0 + (j - 2);
-            if (iy < 0) {
-                iy = ny + iy;
-            }
-            double wx = DSx[i] * (S0y[j] + 0.5 * DSy[j]);
-            double wy = DSy[j] * (S0x[i] + 0.5 * DSx[i]);
-            double wz = S0x[i] * S0y[j] + 0.5 * DSx[i] * S0y[j] + 0.5 * S0x[i] * DSy[j] + one_third * DSx[i] * DSy[j];
+    }
+}
 
-            jx_buff[j] -= factor * dx * wx;
-            jy_buff -= factor * dy * wy;
+__attribute__((always_inline)) inline static void current_deposit_2d_fast(
+    double* restrict rho, double* restrict jx, double* restrict jy, double* restrict jz,
+    double x, double y,
+    double ux, double uy, double uz, double inv_gamma,
+    npy_intp nx, npy_intp ny,
+    double dx, double dy, double x0, double y0, double dt, double w,
+    double q_over_dx_dy, double q_over_dy_dt, double q_over_dx_dt
+) {
+    double vx = ux * LIGHT_SPEED * inv_gamma;
+    double vy = uy * LIGHT_SPEED * inv_gamma;
+    double vz = uz * LIGHT_SPEED * inv_gamma;
+    double x_old = x - vx * 0.5 * dt - x0;
+    double y_old = y - vy * 0.5 * dt - y0;
+    double x_adv = x + vx * 0.5 * dt - x0;
+    double y_adv = y + vy * 0.5 * dt - y0;
 
-            jx[INDEX2(ix, iy)] += jx_buff[j];
-            jy[INDEX2(ix, iy)] += jy_buff;
-            jz[INDEX2(ix, iy)] += factor * dt * wz * vz;
-            rho[INDEX2(ix, iy)] += charge_density * S1x[i] * S1y[j];
+    double x_over_dx0 = x_old / dx;
+    double y_over_dy0 = y_old / dy;
+    double x_over_dx1 = x_adv / dx;
+    double y_over_dy1 = y_adv / dy;
+
+    int ix0, iy0, ix1, iy1;
+    if (x_old >= 0 && x_adv >= 0 && y_old >= 0 && y_adv >= 0) {
+        ix0 = (int)(x_over_dx0 + 0.5);
+        iy0 = (int)(y_over_dy0 + 0.5);
+        ix1 = (int)(x_over_dx1 + 0.5);
+        iy1 = (int)(y_over_dy1 + 0.5);
+    } else {
+        ix0 = (int)floor(x_over_dx0 + 0.5);
+        iy0 = (int)floor(y_over_dy0 + 0.5);
+        ix1 = (int)floor(x_over_dx1 + 0.5);
+        iy1 = (int)floor(y_over_dy1 + 0.5);
+    }
+
+    double S0x[5], S0y[5];
+    calculate_S(ix0 - x_over_dx0, 0, S0x);
+    calculate_S(iy0 - y_over_dy0, 0, S0y);
+
+    int dcell_x = ix1 - ix0;
+    int dcell_y = iy1 - iy0;
+
+    double S1x[5], S1y[5], DSx[5], DSy[5];
+    calculate_S(ix1 - x_over_dx1, dcell_x, S1x);
+    calculate_S(iy1 - y_over_dy1, dcell_y, S1y);
+
+    npy_intp i, j;
+    for (i = 0; i < 5; i++) {
+        DSx[i] = S1x[i] - S0x[i];
+        DSy[i] = S1y[i] - S0y[i];
+    }
+
+    double charge_density = q_over_dx_dy * w;
+    double factor_dx = q_over_dy_dt * w;
+    double factor_dy = q_over_dx_dt * w;
+    double factor_dt_vz = charge_density * vz;
+    const double one_twelfth = 1.0 / 12.0;
+
+    int i_start = dcell_x < 0 ? 0 : 1;
+    int i_end = dcell_x > 0 ? 5 : 4;
+    int j_start = dcell_y < 0 ? 0 : 1;
+    int j_end = dcell_y > 0 ? 5 : 4;
+
+    double jx_buff[5] = {0, 0, 0, 0, 0};
+
+    for (i = i_start; i < i_end; i++) {
+        int ix = ix0 + (i - 2);
+        if (ix < 0) ix = nx + ix;
+        double jy_buff = 0.0;
+        npy_intp ix_ny = ix * ny;
+        double a = S0x[i] + 0.5 * DSx[i];
+        double factor_dx_DSx_i = factor_dx * DSx[i];
+        double one_twelfth_DSx_i = one_twelfth * DSx[i];
+        for (j = j_start; j < j_end; j++) {
+            int iy = iy0 + (j - 2);
+            if (iy < 0) iy = ny + iy;
+            double b = S0y[j] + 0.5 * DSy[j];
+            double wy = DSy[j] * a;
+            double wz = a * b + one_twelfth_DSx_i * DSy[j];
+
+            jx_buff[j] -= factor_dx_DSx_i * b;
+            jy_buff -= factor_dy * wy;
+
+            npy_intp idx = iy + ix_ny;
+            jx[idx] += jx_buff[j];
+            jy[idx] += jy_buff;
+            jz[idx] += factor_dt_vz * wz;
+            rho[idx] += charge_density * S1x[i] * S1y[j];
         }
     }
 }

--- a/src/lambdapic/core/current/current_deposit.h
+++ b/src/lambdapic/core/current/current_deposit.h
@@ -80,6 +80,8 @@ __attribute__((always_inline)) inline static void current_deposit_2d(
     double factor_dt_vz = factor * dt * vz;
     const double one_twelfth = 1.0 / 12.0;
 
+    // These bounds are correct only when a particle crosses at most one cell
+    // per step (|dcell| <= 1), which is the usual PIC CFL condition.
     int i_start = dcell_x < 0 ? 0 : 1;
     int i_end = dcell_x > 0 ? 5 : 4;
     int j_start = dcell_y < 0 ? 0 : 1;
@@ -171,6 +173,8 @@ __attribute__((always_inline)) inline static void current_deposit_2d_fast(
     double factor_dt_vz = charge_density * vz;
     const double one_twelfth = 1.0 / 12.0;
 
+    // These bounds are correct only when a particle crosses at most one cell
+    // per step (|dcell| <= 1), which is the usual PIC CFL condition.
     int i_start = dcell_x < 0 ? 0 : 1;
     int i_end = dcell_x > 0 ? 5 : 4;
     int j_start = dcell_y < 0 ? 0 : 1;
@@ -272,6 +276,8 @@ __attribute__((always_inline)) inline static void current_deposit_3d_fast(
     double factor_dy = q_over_dx_dz_dt * w;
     double factor_dz = q_over_dx_dy_dt * w;
 
+    // These bounds are correct only when a particle crosses at most one cell
+    // per step (|dcell| <= 1), which is the usual PIC CFL condition.
     int i_start = dcell_x < 0 ? 0 : 1;
     int i_end = dcell_x > 0 ? 5 : 4;
     int j_start = dcell_y < 0 ? 0 : 1;

--- a/src/lambdapic/core/pusher/unified/unified_pusher_2d.c
+++ b/src/lambdapic/core/pusher/unified/unified_pusher_2d.c
@@ -7,14 +7,12 @@
 #include "../../current/current_deposit.h"
 
 
-inline static void boris(
-    double* ux, double* uy, double* uz, double* inv_gamma,
+__attribute__((always_inline)) inline static void boris(
+    double* restrict ux, double* restrict uy, double* restrict uz, double* restrict inv_gamma,
     double Ex, double Ey, double Ez,
     double Bx, double By, double Bz,
-    double q, double m, double dt
+    double efactor, double bfactor
 ) {
-    const double efactor = q * dt / (2 * m * LIGHT_SPEED);
-    const double bfactor = q * dt / (2 * m);
 
     // E field half acceleration
     double ux_minus = *ux + efactor * Ex;
@@ -47,76 +45,107 @@ inline static void boris(
     *inv_gamma = 1.0 / sqrt(1 + (*ux) * (*ux) + (*uy) * (*uy) + (*uz) * (*uz));
 }
 
-inline static void push_position_2d(
-    double* x, double* y,
+__attribute__((always_inline)) inline static void push_position_2d(
+    double* restrict x, double* restrict y,
     double ux, double uy,
     double inv_gamma,
-    double dt
+    double cdt
 ) {
-    const double cdt = LIGHT_SPEED * dt;
     *x += cdt * inv_gamma * ux;
     *y += cdt * inv_gamma * uy;
 }
 
 
-inline static void get_gx(double delta, double* gx) {
+__attribute__((always_inline)) inline static void get_gx(double delta, double* gx) {
     double delta2 = delta * delta;
     gx[0] = 0.5 * (0.25 + delta2 + delta);
     gx[1] = 0.75 - delta2;
     gx[2] = 0.5 * (0.25 + delta2 - delta);
 }
 
-inline static double interp_field(double* field, double* fac1, double* fac2, npy_intp ix, npy_intp iy, npy_intp nx, npy_intp ny) {
-    double field_part = 
-          fac2[0] * (fac1[0] * field[INDEX2(ix-1, iy-1)] 
-        +            fac1[1] * field[INDEX2(ix,   iy-1)] 
+// Slow path: uses INDEX2 with periodic boundary checks
+__attribute__((always_inline)) inline static double interp_field_safe(double* restrict field, double* restrict fac1, double* restrict fac2, npy_intp ix, npy_intp iy, npy_intp nx, npy_intp ny) {
+    double field_part =
+          fac2[0] * (fac1[0] * field[INDEX2(ix-1, iy-1)]
+        +            fac1[1] * field[INDEX2(ix,   iy-1)]
         +            fac1[2] * field[INDEX2(ix+1, iy-1)])
-        + fac2[1] * (fac1[0] * field[INDEX2(ix-1, iy  )] 
-        +            fac1[1] * field[INDEX2(ix,   iy  )] 
-        +            fac1[2] * field[INDEX2(ix+1, iy  )]) 
-        + fac2[2] * (fac1[0] * field[INDEX2(ix-1, iy+1)] 
-        +            fac1[1] * field[INDEX2(ix,   iy+1)] 
+        + fac2[1] * (fac1[0] * field[INDEX2(ix-1, iy  )]
+        +            fac1[1] * field[INDEX2(ix,   iy  )]
+        +            fac1[2] * field[INDEX2(ix+1, iy  )])
+        + fac2[2] * (fac1[0] * field[INDEX2(ix-1, iy+1)]
+        +            fac1[1] * field[INDEX2(ix,   iy+1)]
         +            fac1[2] * field[INDEX2(ix+1, iy+1)]);
     return field_part;
 }
 
-inline static void interpolation_2d(
-    double x, double y, 
-    double* ex_part, double* ey_part, double* ez_part, 
-    double* bx_part, double* by_part, double* bz_part, 
-    double* ex, double* ey, double* ez, 
-    double* bx, double* by, double* bz, 
-    double dx, double dy, double x0, double y0, 
+__attribute__((always_inline)) inline static double interp_field_fast(
+    double* restrict field, double* restrict fac1, double* restrict fac2,
+    int ix, int iy, int ny
+) {
+    int im1 = (ix - 1) * ny, i0 = ix * ny, ip1 = (ix + 1) * ny;
+    int jm1 = iy - 1, j0 = iy, jp1 = iy + 1;
+    return fac2[0] * (fac1[0] * field[im1 + jm1] + fac1[1] * field[i0 + jm1] + fac1[2] * field[ip1 + jm1])
+         + fac2[1] * (fac1[0] * field[im1 + j0]  + fac1[1] * field[i0 + j0]  + fac1[2] * field[ip1 + j0])
+         + fac2[2] * (fac1[0] * field[im1 + jp1] + fac1[1] * field[i0 + jp1] + fac1[2] * field[ip1 + jp1]);
+}
+
+__attribute__((always_inline)) inline static void interpolation_2d(
+    double x, double y,
+    double* restrict ex_part, double* restrict ey_part, double* restrict ez_part,
+    double* restrict bx_part, double* restrict by_part, double* restrict bz_part,
+    double* restrict ex, double* restrict ey, double* restrict ez,
+    double* restrict bx, double* restrict by, double* restrict bz,
+    double inv_dx, double inv_dy, double x0, double y0,
     npy_intp nx, npy_intp ny
 ) {
-    
+
     double gx[3];
     double gy[3];
     double hx[3];
     double hy[3];
-    
-    double x_over_dx = (x - x0) / dx;
-    double y_over_dy = (y - y0) / dy;
 
-    npy_intp ix1 = (int)floor(x_over_dx + 0.5);
-    get_gx(ix1 - x_over_dx, gx);
+    double x_over_dx = (x - x0) * inv_dx;
+    double y_over_dy = (y - y0) * inv_dy;
 
-    npy_intp ix2 = (int)floor(x_over_dx);
-    get_gx(ix2 - x_over_dx + 0.5, hx);
+    // Fast pre-computation with (int) - safe if result passes bounds check
+    int ix1_fast = (int)(x_over_dx + 0.5);
+    int ix2_fast = (int)x_over_dx;
+    int iy1_fast = (int)(y_over_dy + 0.5);
+    int iy2_fast = (int)y_over_dy;
 
-    npy_intp iy1 = (int)floor(y_over_dy + 0.5);
-    get_gx(iy1 - y_over_dy, gy);
+    int use_fast_path = (ix2_fast > 0 && ix2_fast < nx - 1 && ix1_fast > 0 && ix1_fast < nx - 1 &&
+                         iy2_fast > 0 && iy2_fast < ny - 1 && iy1_fast > 0 && iy1_fast < ny - 1);
 
-    npy_intp iy2 = (int)floor(y_over_dy);
-    get_gx(iy2 - y_over_dy + 0.5, hy);
+    if (use_fast_path) {
+        get_gx(ix1_fast - x_over_dx, gx);
+        get_gx(ix2_fast - x_over_dx + 0.5, hx);
+        get_gx(iy1_fast - y_over_dy, gy);
+        get_gx(iy2_fast - y_over_dy + 0.5, hy);
 
-    *ex_part = interp_field(ex, hx, gy, ix2, iy1, nx, ny);
-    *ey_part = interp_field(ey, gx, hy, ix1, iy2, nx, ny);
-    *ez_part = interp_field(ez, gx, gy, ix1, iy1, nx, ny);
+        *ex_part = interp_field_fast(ex, hx, gy, ix2_fast, iy1_fast, ny);
+        *ey_part = interp_field_fast(ey, gx, hy, ix1_fast, iy2_fast, ny);
+        *ez_part = interp_field_fast(ez, gx, gy, ix1_fast, iy1_fast, ny);
+        *bx_part = interp_field_fast(bx, gx, hy, ix1_fast, iy2_fast, ny);
+        *by_part = interp_field_fast(by, hx, gy, ix2_fast, iy1_fast, ny);
+        *bz_part = interp_field_fast(bz, hx, hy, ix2_fast, iy2_fast, ny);
+    } else {
+        npy_intp ix1 = (int)floor(x_over_dx + 0.5);
+        get_gx(ix1 - x_over_dx, gx);
+        npy_intp ix2 = (int)floor(x_over_dx);
+        get_gx(ix2 - x_over_dx + 0.5, hx);
+        npy_intp iy1 = (int)floor(y_over_dy + 0.5);
+        get_gx(iy1 - y_over_dy, gy);
+        npy_intp iy2 = (int)floor(y_over_dy);
+        get_gx(iy2 - y_over_dy + 0.5, hy);
 
-    *bx_part = interp_field(bx, gx, hy, ix1, iy2, nx, ny);
-    *by_part = interp_field(by, hx, gy, ix2, iy1, nx, ny);
-    *bz_part = interp_field(bz, hx, hy, ix2, iy2, nx, ny);
+        *ex_part = interp_field_safe(ex, hx, gy, ix2, iy1, nx, ny);
+        *ey_part = interp_field_safe(ey, gx, hy, ix1, iy2, nx, ny);
+        *ez_part = interp_field_safe(ez, gx, gy, ix1, iy1, nx, ny);
+
+        *bx_part = interp_field_safe(bx, gx, hy, ix1, iy2, nx, ny);
+        *by_part = interp_field_safe(by, hx, gy, ix2, iy1, nx, ny);
+        *bz_part = interp_field_safe(bz, hx, hy, ix2, iy2, nx, ny);
+    }
 }
 
 
@@ -178,44 +207,88 @@ static PyObject* unified_boris_pusher_cpu_2d(PyObject* self, PyObject* args) {
     Py_BEGIN_ALLOW_THREADS
     #pragma omp parallel for
     for (npy_intp ipatch = 0; ipatch < npatches; ipatch++) {
-        for (npy_intp ip = 0; ip < npart[ipatch]; ip++) {
-            if (is_dead[ipatch][ip]) continue;
-            if (isnan(x[ipatch][ip]) || isnan(y[ipatch][ip])) continue;
-            
+        // Cache patch-local pointers to avoid double indirection
+        double* x_patch = x[ipatch];
+        double* y_patch = y[ipatch];
+        double* ux_patch = ux[ipatch];
+        double* uy_patch = uy[ipatch];
+        double* uz_patch = uz[ipatch];
+        double* inv_gamma_patch = inv_gamma[ipatch];
+        double* ex_part_patch = ex_part[ipatch];
+        double* ey_part_patch = ey_part[ipatch];
+        double* ez_part_patch = ez_part[ipatch];
+        double* bx_part_patch = bx_part[ipatch];
+        double* by_part_patch = by_part[ipatch];
+        double* bz_part_patch = bz_part[ipatch];
+        npy_bool* is_dead_patch = is_dead[ipatch];
+        double* w_patch = w[ipatch];
+        
+        double* ex_field = ex[ipatch];
+        double* ey_field = ey[ipatch];
+        double* ez_field = ez[ipatch];
+        double* bx_field = bx[ipatch];
+        double* by_field = by[ipatch];
+        double* bz_field = bz[ipatch];
+        double* rho_field = rho[ipatch];
+        double* jx_field = jx[ipatch];
+        double* jy_field = jy[ipatch];
+        double* jz_field = jz[ipatch];
+        
+        double x0_patch = x0[ipatch];
+        double y0_patch = y0[ipatch];
+        npy_intp npart_patch = npart[ipatch];
+        
+        const double efactor = q * dt / (2 * m * LIGHT_SPEED);
+        const double bfactor = q * dt / (2 * m);
+        const double cdt_half = LIGHT_SPEED * 0.5 * dt;
+        const double q_over_dx_dy = q / (dx * dy);
+        const double q_over_dy_dt = q / (dy * dt);
+        const double q_over_dx_dt = q / (dx * dt);
+        const double inv_dx = 1.0 / dx;
+        const double inv_dy = 1.0 / dy;
+
+        // Phase 1: position push, interpolation, Boris push, position push
+        for (npy_intp ip = 0; ip < npart_patch; ip++) {
+            if (is_dead_patch[ip]) continue;
             push_position_2d(
-                &x[ipatch][ip], &y[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], inv_gamma[ipatch][ip], 
-                0.5*dt
+                &x_patch[ip], &y_patch[ip],
+                ux_patch[ip], uy_patch[ip], inv_gamma_patch[ip],
+                cdt_half
             );
             interpolation_2d(
-                x[ipatch][ip], y[ipatch][ip], 
-                &ex_part[ipatch][ip], &ey_part[ipatch][ip], &ez_part[ipatch][ip], 
-                &bx_part[ipatch][ip], &by_part[ipatch][ip], &bz_part[ipatch][ip], 
-                ex[ipatch], ey[ipatch], ez[ipatch], 
-                bx[ipatch], by[ipatch], bz[ipatch], 
-                dx, dy, x0[ipatch], y0[ipatch], 
+                x_patch[ip], y_patch[ip],
+                &ex_part_patch[ip], &ey_part_patch[ip], &ez_part_patch[ip],
+                &bx_part_patch[ip], &by_part_patch[ip], &bz_part_patch[ip],
+                ex_field, ey_field, ez_field,
+                bx_field, by_field, bz_field,
+                inv_dx, inv_dy, x0_patch, y0_patch,
                 nx, ny
             );
             boris(
-                &ux[ipatch][ip], &uy[ipatch][ip], &uz[ipatch][ip], &inv_gamma[ipatch][ip],
-                ex_part[ipatch][ip], ey_part[ipatch][ip], ez_part[ipatch][ip], 
-                bx_part[ipatch][ip], by_part[ipatch][ip], bz_part[ipatch][ip],
-                q, m, dt
+                &ux_patch[ip], &uy_patch[ip], &uz_patch[ip], &inv_gamma_patch[ip],
+                ex_part_patch[ip], ey_part_patch[ip], ez_part_patch[ip],
+                bx_part_patch[ip], by_part_patch[ip], bz_part_patch[ip],
+                efactor, bfactor
             );
             push_position_2d(
-                &x[ipatch][ip], &y[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], inv_gamma[ipatch][ip], 
-                0.5*dt
-            );
-            current_deposit_2d(
-                rho[ipatch], jx[ipatch], jy[ipatch], jz[ipatch], 
-                x[ipatch][ip], y[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], uz[ipatch][ip], inv_gamma[ipatch][ip],
-                nx, ny,
-                dx, dy, x0[ipatch], y0[ipatch], dt, w[ipatch][ip], q
+                &x_patch[ip], &y_patch[ip],
+                ux_patch[ip], uy_patch[ip], inv_gamma_patch[ip],
+                cdt_half
             );
         }
 
+        // Phase 2: current deposit
+        for (npy_intp ip = 0; ip < npart_patch; ip++) {
+            if (is_dead_patch[ip]) continue;
+            current_deposit_2d_fast(
+                rho_field, jx_field, jy_field, jz_field,
+                x_patch[ip], y_patch[ip],
+                ux_patch[ip], uy_patch[ip], uz_patch[ip], inv_gamma_patch[ip],
+                nx, ny,
+                dx, dy, x0_patch, y0_patch, dt, w_patch[ip],
+                q_over_dx_dy, q_over_dy_dt, q_over_dx_dt
+            );
+        }
     }
     // acquire GIL
     Py_END_ALLOW_THREADS

--- a/src/lambdapic/core/pusher/unified/unified_pusher_2d.c
+++ b/src/lambdapic/core/pusher/unified/unified_pusher_2d.c
@@ -250,6 +250,7 @@ static PyObject* unified_boris_pusher_cpu_2d(PyObject* self, PyObject* args) {
         // Phase 1: position push, interpolation, Boris push, position push
         for (npy_intp ip = 0; ip < npart_patch; ip++) {
             if (is_dead_patch[ip]) continue;
+            if (isnan(x_patch[ip]) || isnan(y_patch[ip])) continue;
             push_position_2d(
                 &x_patch[ip], &y_patch[ip],
                 ux_patch[ip], uy_patch[ip], inv_gamma_patch[ip],
@@ -280,6 +281,7 @@ static PyObject* unified_boris_pusher_cpu_2d(PyObject* self, PyObject* args) {
         // Phase 2: current deposit
         for (npy_intp ip = 0; ip < npart_patch; ip++) {
             if (is_dead_patch[ip]) continue;
+            if (isnan(x_patch[ip]) || isnan(y_patch[ip])) continue;
             current_deposit_2d_fast(
                 rho_field, jx_field, jy_field, jz_field,
                 x_patch[ip], y_patch[ip],

--- a/src/lambdapic/core/pusher/unified/unified_pusher_3d.c
+++ b/src/lambdapic/core/pusher/unified/unified_pusher_3d.c
@@ -321,6 +321,7 @@ static PyObject* unified_boris_pusher_cpu_3d(PyObject* self, PyObject* args) {
         // Phase 1: position push, interpolation, Boris push, position push
         for (npy_intp ip = 0; ip < npart_patch; ip++) {
             if (is_dead_patch[ip]) continue;
+            if (isnan(x_patch[ip]) || isnan(y_patch[ip]) || isnan(z_patch[ip])) continue;
             push_position_3d(
                 &x_patch[ip], &y_patch[ip], &z_patch[ip],
                 ux_patch[ip], uy_patch[ip], uz_patch[ip], inv_gamma_patch[ip],
@@ -351,6 +352,7 @@ static PyObject* unified_boris_pusher_cpu_3d(PyObject* self, PyObject* args) {
         // Phase 2: current deposit
         for (npy_intp ip = 0; ip < npart_patch; ip++) {
             if (is_dead_patch[ip]) continue;
+            if (isnan(x_patch[ip]) || isnan(y_patch[ip]) || isnan(z_patch[ip])) continue;
             current_deposit_3d_fast(
                 rho_field, jx_field, jy_field, jz_field,
                 x_patch[ip], y_patch[ip], z_patch[ip],

--- a/src/lambdapic/core/pusher/unified/unified_pusher_3d.c
+++ b/src/lambdapic/core/pusher/unified/unified_pusher_3d.c
@@ -4,16 +4,15 @@
 #include <math.h>
 
 #include "../../utils/cutils.h"
+#include "../../current/current_deposit.h"
 
 
-inline static void boris(
-    double* ux, double* uy, double* uz, double* inv_gamma,
+__attribute__((always_inline)) inline static void boris(
+    double* restrict ux, double* restrict uy, double* restrict uz, double* restrict inv_gamma,
     double Ex, double Ey, double Ez,
     double Bx, double By, double Bz,
-    double q, double m, double dt
+    double efactor, double bfactor
 ) {
-    const double efactor = q * dt / (2 * m * LIGHT_SPEED);
-    const double bfactor = q * dt / (2 * m);
 
     // E field half acceleration
     double ux_minus = *ux + efactor * Ex;
@@ -46,33 +45,33 @@ inline static void boris(
     *inv_gamma = 1.0 / sqrt(1 + (*ux) * (*ux) + (*uy) * (*uy) + (*uz) * (*uz));
 }
 
-inline static void push_position_3d(
-    double* x, double* y, double* z,
+__attribute__((always_inline)) inline static void push_position_3d(
+    double* restrict x, double* restrict y, double* restrict z,
     double ux, double uy, double uz,
     double inv_gamma,
-    double dt
+    double cdt
 ) {
-    const double cdt = LIGHT_SPEED * dt;
     *x += cdt * inv_gamma * ux;
     *y += cdt * inv_gamma * uy;
     *z += cdt * inv_gamma * uz;
 }
 
 
-inline static void get_gx(double delta, double* gx) {
+__attribute__((always_inline)) inline static void get_gx(double delta, double* gx) {
     double delta2 = delta * delta;
     gx[0] = 0.5 * (0.25 + delta2 + delta);
     gx[1] = 0.75 - delta2;
     gx[2] = 0.5 * (0.25 + delta2 - delta);
 }
 
-inline static double interp_field(
-    double* field, 
-    double* facx, double* facy, double* facz, 
-    npy_intp ix, npy_intp iy, npy_intp iz, 
+// Slow path: uses INDEX3 with periodic boundary checks
+__attribute__((always_inline)) inline static double interp_field_safe_3d(
+    double* restrict field,
+    double* restrict facx, double* restrict facy, double* restrict facz,
+    npy_intp ix, npy_intp iy, npy_intp iz,
     npy_intp nx, npy_intp ny, npy_intp nz
 ) {
-    double field_part = 
+    double field_part =
           facz[0] * (facy[0] * (facx[0] * field[INDEX3(ix-1, iy-1, iz-1)]
         +                       facx[1] * field[INDEX3(ix  , iy-1, iz-1)]
         +                       facx[2] * field[INDEX3(ix+1, iy-1, iz-1)])
@@ -103,152 +102,112 @@ inline static double interp_field(
     return field_part;
 }
 
-inline static void interpolation_3d(
+__attribute__((always_inline)) inline static double interp_field_fast_3d(
+    double* restrict field,
+    double* restrict facx, double* restrict facy, double* restrict facz,
+    int ix, int iy, int iz,
+    int ny, int nz
+) {
+    int ny_nz = ny * nz;
+    int im1 = (ix - 1) * ny_nz, i0 = ix * ny_nz, ip1 = (ix + 1) * ny_nz;
+    int jm1 = (iy - 1) * nz, j0 = iy * nz, jp1 = (iy + 1) * nz;
+    int km1 = iz - 1, k0 = iz, kp1 = iz + 1;
+    return facz[0] * (facy[0] * (facx[0] * field[im1 + jm1 + km1]
+                              + facx[1] * field[i0  + jm1 + km1]
+                              + facx[2] * field[ip1 + jm1 + km1])
+                    + facy[1] * (facx[0] * field[im1 + j0  + km1]
+                              + facx[1] * field[i0  + j0  + km1]
+                              + facx[2] * field[ip1 + j0  + km1])
+                    + facy[2] * (facx[0] * field[im1 + jp1 + km1]
+                              + facx[1] * field[i0  + jp1 + km1]
+                              + facx[2] * field[ip1 + jp1 + km1]))
+         + facz[1] * (facy[0] * (facx[0] * field[im1 + jm1 + k0]
+                              + facx[1] * field[i0  + jm1 + k0]
+                              + facx[2] * field[ip1 + jm1 + k0])
+                    + facy[1] * (facx[0] * field[im1 + j0  + k0]
+                              + facx[1] * field[i0  + j0  + k0]
+                              + facx[2] * field[ip1 + j0  + k0])
+                    + facy[2] * (facx[0] * field[im1 + jp1 + k0]
+                              + facx[1] * field[i0  + jp1 + k0]
+                              + facx[2] * field[ip1 + jp1 + k0]))
+         + facz[2] * (facy[0] * (facx[0] * field[im1 + jm1 + kp1]
+                              + facx[1] * field[i0  + jm1 + kp1]
+                              + facx[2] * field[ip1 + jm1 + kp1])
+                    + facy[1] * (facx[0] * field[im1 + j0  + kp1]
+                              + facx[1] * field[i0  + j0  + kp1]
+                              + facx[2] * field[ip1 + j0  + kp1])
+                    + facy[2] * (facx[0] * field[im1 + jp1 + kp1]
+                              + facx[1] * field[i0  + jp1 + kp1]
+                              + facx[2] * field[ip1 + jp1 + kp1]));
+}
+
+__attribute__((always_inline)) inline static void interpolation_3d(
     double x, double y, double z,
-    double* ex_part, double* ey_part, double* ez_part, 
-    double* bx_part, double* by_part, double* bz_part, 
-    double* ex, double* ey, double* ez, 
-    double* bx, double* by, double* bz, 
-    double dx, double dy, double dz, double x0, double y0, double z0, 
+    double* restrict ex_part, double* restrict ey_part, double* restrict ez_part,
+    double* restrict bx_part, double* restrict by_part, double* restrict bz_part,
+    double* restrict ex, double* restrict ey, double* restrict ez,
+    double* restrict bx, double* restrict by, double* restrict bz,
+    double inv_dx, double inv_dy, double inv_dz, double x0, double y0, double z0,
     npy_intp nx, npy_intp ny, npy_intp nz
 ) {
-    
+
     double gx[3];
     double gy[3];
     double gz[3];
     double hx[3];
     double hy[3];
     double hz[3];
-    
-    double x_over_dx = (x - x0) / dx;
-    double y_over_dy = (y - y0) / dy;
-    double z_over_dz = (z - z0) / dz;
 
-    npy_intp ix1 = (int)floor(x_over_dx + 0.5);
-    get_gx(ix1 - x_over_dx, gx);
+    double x_over_dx = (x - x0) * inv_dx;
+    double y_over_dy = (y - y0) * inv_dy;
+    double z_over_dz = (z - z0) * inv_dz;
 
-    npy_intp ix2 = (int)floor(x_over_dx);
-    get_gx(ix2 - x_over_dx + 0.5, hx);
+    // Fast pre-computation with (int) - safe if result passes bounds check
+    int ix1_fast = (int)(x_over_dx + 0.5);
+    int ix2_fast = (int)x_over_dx;
+    int iy1_fast = (int)(y_over_dy + 0.5);
+    int iy2_fast = (int)y_over_dy;
+    int iz1_fast = (int)(z_over_dz + 0.5);
+    int iz2_fast = (int)z_over_dz;
 
-    npy_intp iy1 = (int)floor(y_over_dy + 0.5);
-    get_gx(iy1 - y_over_dy, gy);
+    int use_fast_path = (ix2_fast > 0 && ix2_fast < nx - 1 && ix1_fast > 0 && ix1_fast < nx - 1 &&
+                         iy2_fast > 0 && iy2_fast < ny - 1 && iy1_fast > 0 && iy1_fast < ny - 1 &&
+                         iz2_fast > 0 && iz2_fast < nz - 1 && iz1_fast > 0 && iz1_fast < nz - 1);
 
-    npy_intp iy2 = (int)floor(y_over_dy);
-    get_gx(iy2 - y_over_dy + 0.5, hy);
+    if (use_fast_path) {
+        get_gx(ix1_fast - x_over_dx, gx);
+        get_gx(ix2_fast - x_over_dx + 0.5, hx);
+        get_gx(iy1_fast - y_over_dy, gy);
+        get_gx(iy2_fast - y_over_dy + 0.5, hy);
+        get_gx(iz1_fast - z_over_dz, gz);
+        get_gx(iz2_fast - z_over_dz + 0.5, hz);
 
-    npy_intp iz1 = (int)floor(z_over_dz + 0.5);
-    get_gx(iz1 - z_over_dz, gz);
+        *ex_part = interp_field_fast_3d(ex, hx, gy, gz, ix2_fast, iy1_fast, iz1_fast, ny, nz);
+        *ey_part = interp_field_fast_3d(ey, gx, hy, gz, ix1_fast, iy2_fast, iz1_fast, ny, nz);
+        *ez_part = interp_field_fast_3d(ez, gx, gy, hz, ix1_fast, iy1_fast, iz2_fast, ny, nz);
+        *bx_part = interp_field_fast_3d(bx, gx, hy, hz, ix1_fast, iy2_fast, iz2_fast, ny, nz);
+        *by_part = interp_field_fast_3d(by, hx, gy, hz, ix2_fast, iy1_fast, iz2_fast, ny, nz);
+        *bz_part = interp_field_fast_3d(bz, hx, hy, gz, ix2_fast, iy2_fast, iz1_fast, ny, nz);
+    } else {
+        npy_intp ix1 = (int)floor(x_over_dx + 0.5);
+        get_gx(ix1 - x_over_dx, gx);
+        npy_intp ix2 = (int)floor(x_over_dx);
+        get_gx(ix2 - x_over_dx + 0.5, hx);
+        npy_intp iy1 = (int)floor(y_over_dy + 0.5);
+        get_gx(iy1 - y_over_dy, gy);
+        npy_intp iy2 = (int)floor(y_over_dy);
+        get_gx(iy2 - y_over_dy + 0.5, hy);
+        npy_intp iz1 = (int)floor(z_over_dz + 0.5);
+        get_gx(iz1 - z_over_dz, gz);
+        npy_intp iz2 = (int)floor(z_over_dz);
+        get_gx(iz2 - z_over_dz + 0.5, hz);
 
-    npy_intp iz2 = (int)floor(z_over_dz);
-    get_gx(iz2 - z_over_dz + 0.5, hz);
-
-    *ex_part = interp_field(ex, hx, gy, gz, ix2, iy1, iz1, nx, ny, nz);
-    *ey_part = interp_field(ey, gx, hy, gz, ix1, iy2, iz1, nx, ny, nz);
-    *ez_part = interp_field(ez, gx, gy, hz, ix1, iy1, iz2, nx, ny, nz);
-
-    *bx_part = interp_field(bx, gx, hy, hz, ix1, iy2, iz2, nx, ny, nz);
-    *by_part = interp_field(by, hx, gy, hz, ix2, iy1, iz2, nx, ny, nz);
-    *bz_part = interp_field(bz, hx, hy, gz, ix2, iy2, iz1, nx, ny, nz);
-}
-
-static void calculate_S(double delta, int shift, double* S) {
-    double delta2 = delta * delta;
-
-    double delta_minus = 0.5 * (delta2 + delta + 0.25);
-    double delta_mid = 0.75 - delta2;
-    double delta_positive = 0.5 * (delta2 - delta + 0.25);
-
-    int minus = shift == -1;
-    int mid = shift == 0;
-    int positive = shift == 1;
-
-    S[0] = minus * delta_minus;
-    S[1] = minus * delta_mid + mid * delta_minus;
-    S[2] = minus * delta_positive + mid * delta_mid + positive * delta_minus;
-    S[3] = mid * delta_positive + positive * delta_mid;
-    S[4] = positive * delta_positive;
-}
-inline static void current_deposit_3d(
-    double* rho, double* jx, double* jy, double* jz, 
-    double x, double y, double z,
-    double ux, double uy, double uz, double inv_gamma,
-    npy_intp nx, npy_intp ny, npy_intp nz,
-    double dx, double dy, double dz, double x0, double y0, double z0, double dt, double w, double q
-) {
-    double vx = ux * LIGHT_SPEED * inv_gamma;
-    double vy = uy * LIGHT_SPEED * inv_gamma;
-    double vz = uz * LIGHT_SPEED * inv_gamma;
-    double x_old = x - vx * 0.5 * dt - x0;
-    double x_adv = x + vx * 0.5 * dt - x0;
-    double y_old = y - vy * 0.5 * dt - y0;
-    double y_adv = y + vy * 0.5 * dt - y0;
-    double z_old = z - vz * 0.5 * dt - z0;
-    double z_adv = z + vz * 0.5 * dt - z0;
-
-    double x_over_dx0 = x_old / dx;
-    int ix0 = (int)floor(x_over_dx0 + 0.5);
-    double y_over_dy0 = y_old / dy;
-    int iy0 = (int)floor(y_over_dy0 + 0.5);
-    double z_over_dz0 = z_old / dz;
-    int iz0 = (int)floor(z_over_dz0 + 0.5);
-
-    double S0x[5], S0y[5], S0z[5];
-    calculate_S(ix0 - x_over_dx0, 0, S0x);
-    calculate_S(iy0 - y_over_dy0, 0, S0y);
-    calculate_S(iz0 - z_over_dz0, 0, S0z);
-
-    double x_over_dx1 = x_adv / dx;
-    int ix1 = (int)floor(x_over_dx1 + 0.5);
-    int dcell_x = ix1 - ix0;
-
-    double y_over_dy1 = y_adv / dy;
-    int iy1 = (int)floor(y_over_dy1 + 0.5);
-    int dcell_y = iy1 - iy0;
-
-    double z_over_dz1 = z_adv / dz;
-    int iz1 = (int)floor(z_over_dz1 + 0.5);
-    int dcell_z = iz1 - iz0;
-    
-    double S1x[5], S1y[5], S1z[5], DSx[5], DSy[5], DSz[5];
-    calculate_S(ix1 - x_over_dx1, dcell_x, S1x);
-    calculate_S(iy1 - y_over_dy1, dcell_y, S1y);
-    calculate_S(iz1 - z_over_dz1, dcell_z, S1z);
-
-    for (int i = 0; i < 5; i++) {
-        DSx[i] = S1x[i] - S0x[i];
-        DSy[i] = S1y[i] - S0y[i];
-        DSz[i] = S1z[i] - S0z[i];
-    }
-
-    double charge_density = q * w / (dx * dy * dz);
-    double factor = charge_density / dt;
-
-    double jx_buff[5][5] = {0};
-    for (int i = fmin(1, 1 + dcell_x); i < fmax(4, 4 + dcell_x); i++) {
-        int ix = ix0 + (i - 2);
-        
-        double jy_buff[5] = {0};
-        for (int j = fmin(1, 1 + dcell_y); j < fmax(4, 4 + dcell_y); j++) {
-            int iy = iy0 + (j - 2);
-            
-            double jz_buff = 0;
-            for (int k = fmin(1, 1 + dcell_z); k < fmax(4, 4 + dcell_z); k++) {
-                int iz = iz0 + (k - 2);
-
-                double wx = DSx[i] * (S0y[j]*S0z[k] + 0.5 * DSy[j]*S0z[k] + 0.5*S0y[j]*DSz[k] + one_third*DSy[j]*DSz[k]);
-                double wy = DSy[j] * (S0x[i]*S0z[k] + 0.5 * DSx[i]*S0z[k] + 0.5*S0x[i]*DSz[k] + one_third*DSx[i]*DSz[k]);
-                double wz = DSz[k] * (S0x[i]*S0y[j] + 0.5 * DSx[i]*S0y[j] + 0.5*S0x[i]*DSy[j] + one_third*DSx[i]*DSy[j]);
-
-                jx_buff[k][j] -= factor * dx * wx;
-                jy_buff[k] -= factor * dy * wy;
-                jz_buff -= factor * dz * wz;
-
-                jx[INDEX3(ix, iy, iz)] += jx_buff[k][j];
-                jy[INDEX3(ix, iy, iz)] += jy_buff[k];
-                jz[INDEX3(ix, iy, iz)] += jz_buff;
-                rho[INDEX3(ix, iy, iz)] += charge_density * S1x[i] * S1y[j] * S1z[k];
-            }
-        }
+        *ex_part = interp_field_safe_3d(ex, hx, gy, gz, ix2, iy1, iz1, nx, ny, nz);
+        *ey_part = interp_field_safe_3d(ey, gx, hy, gz, ix1, iy2, iz1, nx, ny, nz);
+        *ez_part = interp_field_safe_3d(ez, gx, gy, hz, ix1, iy1, iz2, nx, ny, nz);
+        *bx_part = interp_field_safe_3d(bx, gx, hy, hz, ix1, iy2, iz2, nx, ny, nz);
+        *by_part = interp_field_safe_3d(by, hx, gy, hz, ix2, iy1, iz2, nx, ny, nz);
+        *bz_part = interp_field_safe_3d(bz, hx, hy, gz, ix2, iy2, iz1, nx, ny, nz);
     }
 }
 
@@ -257,8 +216,8 @@ static PyObject* unified_boris_pusher_cpu_3d(PyObject* self, PyObject* args) {
     npy_intp npatches;
     double dt, q, m;
 
-    if (!PyArg_ParseTuple(args, "OOnddd", 
-        &particles_list, &fields_list, 
+    if (!PyArg_ParseTuple(args, "OOnddd",
+        &particles_list, &fields_list,
         &npatches, &dt, &q, &m)) {
         return NULL;
     }
@@ -266,7 +225,7 @@ static PyObject* unified_boris_pusher_cpu_3d(PyObject* self, PyObject* args) {
     if (npatches <= 0) {
         Py_RETURN_NONE;
     }
-    
+
     npy_intp nx = PyLong_AsLong(PyObject_GetAttrString(PyList_GET_ITEM(fields_list, 0), "nx"));
     npy_intp ny = PyLong_AsLong(PyObject_GetAttrString(PyList_GET_ITEM(fields_list, 0), "ny"));
     npy_intp nz = PyLong_AsLong(PyObject_GetAttrString(PyList_GET_ITEM(fields_list, 0), "nz"));
@@ -315,44 +274,92 @@ static PyObject* unified_boris_pusher_cpu_3d(PyObject* self, PyObject* args) {
     Py_BEGIN_ALLOW_THREADS
     #pragma omp parallel for
     for (npy_intp ipatch = 0; ipatch < npatches; ipatch++) {
-        for (npy_intp ip = 0; ip < npart[ipatch]; ip++) {
-            if (is_dead[ipatch][ip]) continue;
-            if (isnan(x[ipatch][ip]) || isnan(y[ipatch][ip]) || isnan(z[ipatch][ip])) continue;
-            
+        // Cache patch-local pointers to avoid double indirection
+        double* x_patch = x[ipatch];
+        double* y_patch = y[ipatch];
+        double* z_patch = z[ipatch];
+        double* ux_patch = ux[ipatch];
+        double* uy_patch = uy[ipatch];
+        double* uz_patch = uz[ipatch];
+        double* inv_gamma_patch = inv_gamma[ipatch];
+        double* ex_part_patch = ex_part[ipatch];
+        double* ey_part_patch = ey_part[ipatch];
+        double* ez_part_patch = ez_part[ipatch];
+        double* bx_part_patch = bx_part[ipatch];
+        double* by_part_patch = by_part[ipatch];
+        double* bz_part_patch = bz_part[ipatch];
+        npy_bool* is_dead_patch = is_dead[ipatch];
+        double* w_patch = w[ipatch];
+
+        double* ex_field = ex[ipatch];
+        double* ey_field = ey[ipatch];
+        double* ez_field = ez[ipatch];
+        double* bx_field = bx[ipatch];
+        double* by_field = by[ipatch];
+        double* bz_field = bz[ipatch];
+        double* rho_field = rho[ipatch];
+        double* jx_field = jx[ipatch];
+        double* jy_field = jy[ipatch];
+        double* jz_field = jz[ipatch];
+
+        double x0_patch = x0[ipatch];
+        double y0_patch = y0[ipatch];
+        double z0_patch = z0[ipatch];
+        npy_intp npart_patch = npart[ipatch];
+
+        const double efactor = q * dt / (2 * m * LIGHT_SPEED);
+        const double bfactor = q * dt / (2 * m);
+        const double cdt_half = LIGHT_SPEED * 0.5 * dt;
+        const double q_over_dx_dy_dz = q / (dx * dy * dz);
+        const double q_over_dy_dz_dt = q / (dy * dz * dt);
+        const double q_over_dx_dz_dt = q / (dx * dz * dt);
+        const double q_over_dx_dy_dt = q / (dx * dy * dt);
+        const double inv_dx = 1.0 / dx;
+        const double inv_dy = 1.0 / dy;
+        const double inv_dz = 1.0 / dz;
+
+        // Phase 1: position push, interpolation, Boris push, position push
+        for (npy_intp ip = 0; ip < npart_patch; ip++) {
+            if (is_dead_patch[ip]) continue;
             push_position_3d(
-                &x[ipatch][ip], &y[ipatch][ip], &z[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], uz[ipatch][ip], inv_gamma[ipatch][ip], 
-                0.5*dt
+                &x_patch[ip], &y_patch[ip], &z_patch[ip],
+                ux_patch[ip], uy_patch[ip], uz_patch[ip], inv_gamma_patch[ip],
+                cdt_half
             );
             interpolation_3d(
-                x[ipatch][ip], y[ipatch][ip], z[ipatch][ip], 
-                &ex_part[ipatch][ip], &ey_part[ipatch][ip], &ez_part[ipatch][ip], 
-                &bx_part[ipatch][ip], &by_part[ipatch][ip], &bz_part[ipatch][ip], 
-                ex[ipatch], ey[ipatch], ez[ipatch], 
-                bx[ipatch], by[ipatch], bz[ipatch], 
-                dx, dy, dz, x0[ipatch], y0[ipatch], z0[ipatch],
+                x_patch[ip], y_patch[ip], z_patch[ip],
+                &ex_part_patch[ip], &ey_part_patch[ip], &ez_part_patch[ip],
+                &bx_part_patch[ip], &by_part_patch[ip], &bz_part_patch[ip],
+                ex_field, ey_field, ez_field,
+                bx_field, by_field, bz_field,
+                inv_dx, inv_dy, inv_dz, x0_patch, y0_patch, z0_patch,
                 nx, ny, nz
             );
             boris(
-                &ux[ipatch][ip], &uy[ipatch][ip], &uz[ipatch][ip], &inv_gamma[ipatch][ip],
-                ex_part[ipatch][ip], ey_part[ipatch][ip], ez_part[ipatch][ip], 
-                bx_part[ipatch][ip], by_part[ipatch][ip], bz_part[ipatch][ip],
-                q, m, dt
+                &ux_patch[ip], &uy_patch[ip], &uz_patch[ip], &inv_gamma_patch[ip],
+                ex_part_patch[ip], ey_part_patch[ip], ez_part_patch[ip],
+                bx_part_patch[ip], by_part_patch[ip], bz_part_patch[ip],
+                efactor, bfactor
             );
             push_position_3d(
-                &x[ipatch][ip], &y[ipatch][ip], &z[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], uz[ipatch][ip], inv_gamma[ipatch][ip], 
-                0.5*dt
-            );
-            current_deposit_3d(
-                rho[ipatch], jx[ipatch], jy[ipatch], jz[ipatch], 
-                x[ipatch][ip], y[ipatch][ip], z[ipatch][ip], 
-                ux[ipatch][ip], uy[ipatch][ip], uz[ipatch][ip], inv_gamma[ipatch][ip],
-                nx, ny, nz,
-                dx, dy, dz, x0[ipatch], y0[ipatch], z0[ipatch], dt, w[ipatch][ip], q
+                &x_patch[ip], &y_patch[ip], &z_patch[ip],
+                ux_patch[ip], uy_patch[ip], uz_patch[ip], inv_gamma_patch[ip],
+                cdt_half
             );
         }
 
+        // Phase 2: current deposit
+        for (npy_intp ip = 0; ip < npart_patch; ip++) {
+            if (is_dead_patch[ip]) continue;
+            current_deposit_3d_fast(
+                rho_field, jx_field, jy_field, jz_field,
+                x_patch[ip], y_patch[ip], z_patch[ip],
+                ux_patch[ip], uy_patch[ip], uz_patch[ip], inv_gamma_patch[ip],
+                nx, ny, nz,
+                dx, dy, dz, x0_patch, y0_patch, z0_patch, dt, w_patch[ip],
+                q_over_dx_dy_dz, q_over_dy_dz_dt, q_over_dx_dz_dt, q_over_dx_dy_dt
+            );
+        }
     }
     // acquire GIL
     Py_END_ALLOW_THREADS


### PR DESCRIPTION
## Summary
- Optimizes `unified_boris_pusher_cpu_2d` and `current_deposit_2d`.
- Ports the 2D pusher optimizations to 3D.
- Restores NaN guards and documents the CFL assumption in the pusher.