### PR TITLE
feat(species): auto-register globally-defined species when add_species() omitted

### DIFF
--- a/src/lambdapic/core/species.py
+++ b/src/lambdapic/core/species.py
@@ -15,6 +15,9 @@ from .utils.enable_mixin import EnableMixin
 
 Profile = Callable[[float, float, float], float] | Callable[[float, float], float]
 
+_ALL_SPECIES: list["Species"] = []
+
+
 class SpeciesConfig(BaseModel):
     name: str = Field(..., description="Name of the particle species")
     charge: int = Field(..., description="Charge number (e.g. -1 for electron, +1 for proton)")
@@ -105,6 +108,24 @@ class Species(EnableMixin):
 
         self._aux_attrs: list[str] = []
         self._ispec: int | None = None
+
+        _ALL_SPECIES.append(self)
+
+    def is_compatible(self, dimension: int) -> bool:
+        """Return True if this species' density/ppc profiles fit the given dimension.
+
+        Plain Python functions whose argument count differs from ``dimension``
+        are incompatible (compile_jit would raise). ints/floats and already-jitted
+        callables are treated as dimension-agnostic.
+        """
+        for func in (self.density, self.ppc):
+            if func is None:
+                continue
+            if inspect.isfunction(func) and not is_jitted(func):
+                if func.__code__.co_argcount != dimension:
+                    return False
+        return True
+
         
     @property
     def ispec(self) -> int:

--- a/src/lambdapic/simulation.py
+++ b/src/lambdapic/simulation.py
@@ -32,7 +32,7 @@ from .core.pusher.pusher import BorisPusher, PhotonPusher, PusherBase
 from .core.qed.pair_production import NonlinearPairProductionLCFA, PairProductionBase
 from .core.qed.radiation import NonlinearComptonLCFA, RadiationBase
 from .core.sort.particle_sort import ParticleSort2D, ParticleSort3D
-from .core.species import Electron, Photon, Species
+from .core.species import Electron, Photon, Species, _ALL_SPECIES
 from .core.utils.logger import configure_logger, logger, rank_log
 from .core.utils.progress_bar import ProgressBar
 from .core.utils.terminal import is_terminal
@@ -310,6 +310,8 @@ class Simulation:
             logger.info(f"Boundary conditions: {self.boundary_conditions}")
             logger.info(f"CPML thickness: {self.cpml_thickness}")
         
+        self._add_default_species_if_empty()
+
         patches_list = [Patches(self.dimension) for _ in range(comm_size)]
         if rank == 0:
             logger.info("Creating patches on rank 0")
@@ -548,6 +550,24 @@ class Simulation:
         # Assign ispec
         for ispec, s in enumerate(self.species):
             s.ispec = ispec
+
+    def _add_default_species_if_empty(self) -> None:
+        """Auto-register globally-defined species when none were added.
+
+        If the user constructed ``Species`` instances but forgot to call
+        ``add_species()``, fall back to the module-level ``_ALL_SPECIES``
+        registry. Only dimension-compatible species are registered. This is a
+        convenience and is logged at warning level. No-op if species were
+        already added or the simulation is already initialized.
+        """
+        if not self.species and not self.initialized and _ALL_SPECIES:
+            compatible = [s for s in _ALL_SPECIES if s.is_compatible(self.dimension)]
+            if compatible:
+                logger.warning(
+                    "No species added via add_species(); auto-registering "
+                    f"{len(compatible)} Species: {[s.name for s in compatible]}"
+                )
+                self.add_species(list(compatible))
 
     def add_collision(self, collision_groups: Sequence[Sequence[Species]]):
         """
@@ -851,6 +871,8 @@ class Simulation:
         if callbacks is None:
             callbacks = []
         stage_callbacks = SimulationCallbacks(callbacks, self)
+
+        self._add_default_species_if_empty()
 
         if not self.initialized:
             self.initialize()

--- a/tests/test_auto_species.py
+++ b/tests/test_auto_species.py
@@ -1,0 +1,88 @@
+import pytest
+
+from lambdapic import Simulation
+from lambdapic.core.species import Electron, Proton, _ALL_SPECIES
+
+
+@pytest.fixture
+def isolated_registry():
+    """Snapshot and isolate the global _ALL_SPECIES registry for the test."""
+    saved = list(_ALL_SPECIES)
+    _ALL_SPECIES.clear()
+    yield _ALL_SPECIES
+    _ALL_SPECIES.clear()
+    _ALL_SPECIES.extend(saved)
+
+
+def _make_sim():
+    return Simulation(
+        nx=32,
+        ny=32,
+        dx=1e-7,
+        dy=1e-7,
+        npatch_x=2,
+        npatch_y=2,
+        dt_cfl=0.95,
+    )
+
+
+def test_run_auto_registers_species(isolated_registry):
+    ele = Electron(density=lambda x, y: 1e25, ppc=4)
+
+    assert _ALL_SPECIES == [ele]
+    assert not ele._ispec == 0 or ele._ispec is None
+
+    sim = _make_sim()
+    assert sim.species == []
+
+    sim.run(nsteps=1)
+
+    assert len(sim.species) == 1
+    assert sim.species[0] is ele
+    assert ele.ispec == 0
+    assert sim.patches.species == [ele]
+
+
+def test_initialize_auto_registers_species(isolated_registry):
+    ele = Electron(density=lambda x, y: 1e25, ppc=4)
+    proton = Proton(density=lambda x, y: 1e25, ppc=4)
+
+    sim = _make_sim()
+    sim.initialize()
+
+    assert len(sim.species) == 2
+    assert sim.species[0] is ele
+    assert sim.species[1] is proton
+    assert ele.ispec == 0
+    assert proton.ispec == 1
+
+
+def test_explicit_add_species_takes_precedence(isolated_registry):
+    leaked = Electron(density=lambda x, y: 1e25, ppc=4)
+
+    explicit = Proton(density=lambda x, y: 1e25, ppc=4)
+
+    sim = _make_sim()
+    sim.add_species([explicit])
+
+    sim.run(nsteps=1)
+
+    assert sim.species == [explicit]
+    assert leaked not in sim.species
+
+
+def test_no_species_no_registry_is_noop(isolated_registry):
+    sim = _make_sim()
+    sim.initialize()
+
+    assert sim.species == []
+
+
+def test_dimension_mismatch_filtered(isolated_registry):
+    ele3d = Electron(density=lambda x, y, z: 1e25, ppc=4)
+
+    sim = _make_sim()
+    sim.initialize()
+
+    assert ele3d not in sim.species
+    assert sim.species == []


### PR DESCRIPTION
Cherry-picks 87b9f73 to bring the auto-register species feature onto main.

- Maintains a module-level _ALL_SPECIES registry in core/species.py.
- Auto-registers dimension-compatible species when no species have been added to a Simulation.
- Filters incompatible plain-function density/ppc profiles via Species.is_compatible().
- Note: the SemiECCSimulation portion from the original commit was dropped because that file is internal-only.